### PR TITLE
🔒 [security] fix missing SSRF validation in handleHTTPManipulation

### DIFF
--- a/app/src/handlers/http-manip.ts
+++ b/app/src/handlers/http-manip.ts
@@ -1,4 +1,5 @@
 import { HTTPManipulator, HTTPManipulationOptions } from '../http-manipulation';
+import { isValidTargetUrl } from '../utils/security';
 
 export async function handleHTTPManipulation(request: Request): Promise<Response> {
     const urlObj = new URL(request.url);
@@ -6,6 +7,13 @@ export async function handleHTTPManipulation(request: Request): Promise<Response
 
     if (!targetUrl) {
         return new Response(JSON.stringify({ error: 'Missing url parameter' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json; charset=UTF-8' },
+        });
+    }
+
+    if (!isValidTargetUrl(targetUrl)) {
+        return new Response(JSON.stringify({ error: 'Invalid URL or restricted IP' }), {
             status: 400,
             headers: { 'content-type': 'application/json; charset=UTF-8' },
         });


### PR DESCRIPTION
🎯 **What:** Fixed a missing SSRF validation vulnerability in the `handleHTTPManipulation` handler.
⚠️ **Risk:** Without validation, an attacker could provide an internal IP address (like `127.0.0.1` or `169.254.169.254`) as the `url` parameter, potentially allowing them to probe or access restricted internal services through the Cloudflare Worker.
🛡️ **Solution:** Imported the `isValidTargetUrl` utility from `app/src/utils/security.ts` and added a validation check that returns a `400 Bad Request` if the target URL is invalid or points to a restricted IP address.

---
*PR created automatically by Jules for task [9628352202432608611](https://jules.google.com/task/9628352202432608611) started by @SecH0us3*