### PR TITLE
🧪 [testing improvement] Add IPv6 validation and tests for isValidTargetUrl

### DIFF
--- a/app/src/utils/security.ts
+++ b/app/src/utils/security.ts
@@ -6,11 +6,48 @@ export function isValidTargetUrl(urlString: string): boolean {
             return false;
         }
 
-        const hostname = url.hostname;
+        let hostname = url.hostname;
         
-        // Bloack localhost and link-local ranges
-        if (hostname === 'localhost' || hostname.includes('127.0.0.1') || hostname === '::1') {
+        // Block localhost and link-local ranges
+        if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1') {
             return false;
+        }
+
+        // IPv6 normalization: remove brackets for easier parsing if present
+        const ipv6Normalized = hostname.startsWith('[') && hostname.endsWith(']')
+            ? hostname.slice(1, -1)
+            : hostname;
+
+        // Block IPv6 internal ranges
+        // Unique Local Address (fc00::/7)
+        if (ipv6Normalized.toLowerCase().startsWith('fc') || ipv6Normalized.toLowerCase().startsWith('fd')) {
+            return false;
+        }
+        // Link-Local Address (fe80::/10)
+        if (ipv6Normalized.toLowerCase().startsWith('fe8') ||
+            ipv6Normalized.toLowerCase().startsWith('fe9') ||
+            ipv6Normalized.toLowerCase().startsWith('fea') ||
+            ipv6Normalized.toLowerCase().startsWith('feb')) {
+            return false;
+        }
+
+        // Check for IPv4-mapped IPv6 (::ffff:0:0/96)
+        if (ipv6Normalized.toLowerCase().startsWith('::ffff:')) {
+            const lastPart = ipv6Normalized.split(':').pop() || '';
+            if (lastPart.includes('.')) {
+                hostname = lastPart; // Treat it as IPv4 for the next check
+            } else {
+                // Handle hex-encoded IPv4-mapped IPv6
+                if (ipv6Normalized.toLowerCase().startsWith('::ffff:7f')) return false; // 127.0.0.0/8
+                if (ipv6Normalized.toLowerCase().startsWith('::ffff:0a') || ipv6Normalized.toLowerCase().startsWith('::ffff:a')) return false; // 10.0.0.0/8
+                if (ipv6Normalized.toLowerCase().startsWith('::ffff:ac')) {
+                    // 172.16.0.0/12 -> ::ffff:ac10:0000 to ::ffff:ac1f:ffff
+                    const match = ipv6Normalized.toLowerCase().match(/^::ffff:(ac[12][0-9a-f]|ac3[01])/);
+                    if (match) return false;
+                }
+                if (ipv6Normalized.toLowerCase().startsWith('::ffff:c0a8')) return false; // 192.168.0.0/16
+                if (ipv6Normalized.toLowerCase().startsWith('::ffff:a9fe')) return false; // 169.254.0.0/16
+            }
         }
 
         // Parse IPv4 to check internal subnets

--- a/app/test/security.spec.ts
+++ b/app/test/security.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { isValidTargetUrl } from '../src/utils/security';
+
+describe('isValidTargetUrl', () => {
+    describe('Valid URLs', () => {
+        it('should allow valid public https URLs', () => {
+            expect(isValidTargetUrl('https://www.google.com')).toBe(true);
+            expect(isValidTargetUrl('https://github.com/test')).toBe(true);
+        });
+
+        it('should allow valid public http URLs', () => {
+            expect(isValidTargetUrl('http://example.com')).toBe(true);
+        });
+
+        it('should allow valid public IP addresses', () => {
+            expect(isValidTargetUrl('http://8.8.8.8')).toBe(true);
+            expect(isValidTargetUrl('http://1.1.1.1')).toBe(true);
+        });
+
+        it('should allow valid public IPv6 addresses', () => {
+            expect(isValidTargetUrl('http://[2001:4860:4860::8888]')).toBe(true);
+        });
+    });
+
+    describe('Invalid Protocols', () => {
+        it('should reject non-http/https protocols', () => {
+            expect(isValidTargetUrl('ftp://example.com')).toBe(false);
+            expect(isValidTargetUrl('file:///etc/passwd')).toBe(false);
+            expect(isValidTargetUrl('gopher://example.com')).toBe(false);
+            expect(isValidTargetUrl('javascript:alert(1)')).toBe(false);
+        });
+    });
+
+    describe('IPv4 Internal Ranges', () => {
+        it('should reject localhost', () => {
+            expect(isValidTargetUrl('http://localhost')).toBe(false);
+            expect(isValidTargetUrl('http://127.0.0.1')).toBe(false);
+            expect(isValidTargetUrl('http://127.0.0.2')).toBe(false);
+        });
+
+        it('should reject 10.0.0.0/8', () => {
+            expect(isValidTargetUrl('http://10.0.0.1')).toBe(false);
+            expect(isValidTargetUrl('http://10.255.255.255')).toBe(false);
+        });
+
+        it('should reject 172.16.0.0/12', () => {
+            expect(isValidTargetUrl('http://172.16.0.1')).toBe(false);
+            expect(isValidTargetUrl('http://172.31.255.255')).toBe(false);
+        });
+
+        it('should reject 192.168.0.0/16', () => {
+            expect(isValidTargetUrl('http://192.168.0.1')).toBe(false);
+            expect(isValidTargetUrl('http://192.168.255.255')).toBe(false);
+        });
+
+        it('should reject 169.254.0.0/16 (link-local)', () => {
+            expect(isValidTargetUrl('http://169.254.0.1')).toBe(false);
+        });
+
+        it('should reject 0.0.0.0/8', () => {
+            expect(isValidTargetUrl('http://0.0.0.0')).toBe(false);
+            expect(isValidTargetUrl('http://0.255.255.255')).toBe(false);
+        });
+    });
+
+    describe('IPv6 Internal Ranges (Current Gap)', () => {
+        it('should reject IPv6 loopback', () => {
+            expect(isValidTargetUrl('http://[::1]')).toBe(false);
+        });
+
+        it('should reject IPv6 Unique Local Address (fc00::/7)', () => {
+            expect(isValidTargetUrl('http://[fc00::1]')).toBe(false);
+            expect(isValidTargetUrl('http://[fd00::1]')).toBe(false);
+        });
+
+        it('should reject IPv6 Link-Local Address (fe80::/10)', () => {
+            expect(isValidTargetUrl('http://[fe80::1]')).toBe(false);
+        });
+
+        it('should reject IPv4-mapped IPv6 internal addresses', () => {
+            expect(isValidTargetUrl('http://[::ffff:127.0.0.1]')).toBe(false);
+            expect(isValidTargetUrl('http://[::ffff:10.0.0.1]')).toBe(false);
+            expect(isValidTargetUrl('http://[::ffff:192.168.0.1]')).toBe(false);
+        });
+    });
+
+    describe('Invalid URL formats', () => {
+        it('should reject malformed URLs', () => {
+            expect(isValidTargetUrl('not-a-url')).toBe(false);
+            expect(isValidTargetUrl('')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Add IPv6 validation and comprehensive tests for the `isValidTargetUrl` security utility.

---
*PR created automatically by Jules for task [9811225007869512678](https://jules.google.com/task/9811225007869512678) started by @SecH0us3*