### PR TITLE
🧹 [code health] Remove unused exports in http-manipulation.ts

### DIFF
--- a/app/src/http-manipulation.ts
+++ b/app/src/http-manipulation.ts
@@ -505,24 +505,3 @@ export class HTTPManipulator {
   }
 }
 
-// Export specific techniques for targeted testing
-export const VerbTampering = {
-  uncommonMethods: HTTPManipulator.getUncommonMethods(),
-  generateOverrides: HTTPManipulator.generateMethodOverrides
-};
-
-export const ParameterPollution = {
-  generate: HTTPManipulator.generateParameterPollution
-};
-
-export const ContentTypeConfusion = {
-  variations: HTTPManipulator.getContentTypeVariations()
-};
-
-export const RequestSmuggling = {
-  headers: HTTPManipulator.generateRequestSmugglingHeaders()
-};
-
-export const HostHeaderInjection = {
-  generate: HTTPManipulator.generateHostHeaderVariations
-};


### PR DESCRIPTION
🎯 **What:** Removed unused exports `HostHeaderInjection`, `VerbTampering`, `ParameterPollution`, `ContentTypeConfusion`, and `RequestSmuggling` from `app/src/http-manipulation.ts`.
💡 **Why:** These exports were redundant wrappers around `HTTPManipulator` class methods and had no external references in the codebase or test suite. Removing them improves maintainability and cleans up the module's public API.
✅ **Verification:**
- Used `grep` to confirm no external references exist for these exports.
- Programmatically verified that `HTTPManipulator` still functions correctly by generating requests using `node --experimental-strip-types`.
- Confirmed the exports are no longer present in the module via an import test.
✨ **Result:** A cleaner and more maintainable `http-manipulation.ts` module with no dead code exports.

---
*PR created automatically by Jules for task [6361975936693293929](https://jules.google.com/task/6361975936693293929) started by @SecH0us3*