### PR TITLE
🔒 Fix SSRF vulnerability in handleWAFDetection

### DIFF
--- a/app/src/handlers/waf-detect.ts
+++ b/app/src/handlers/waf-detect.ts
@@ -1,4 +1,5 @@
 import { WAFDetector } from '../waf-detection';
+import { isValidTargetUrl } from '../utils/security';
 
 export async function handleWAFDetection(request: Request): Promise<Response> {
 	const urlObj = new URL(request.url);
@@ -6,6 +7,13 @@ export async function handleWAFDetection(request: Request): Promise<Response> {
 
 	if (!targetUrl) {
 		return new Response(JSON.stringify({ error: 'Missing url parameter' }), {
+			status: 400,
+			headers: { 'content-type': 'application/json; charset=UTF-8' },
+		});
+	}
+
+	if (!isValidTargetUrl(targetUrl)) {
+		return new Response(JSON.stringify({ error: 'Invalid URL or restricted IP' }), {
 			status: 400,
 			headers: { 'content-type': 'application/json; charset=UTF-8' },
 		});


### PR DESCRIPTION
🎯 **What:** Added missing `isValidTargetUrl` check for the user-supplied `url` parameter in `handleWAFDetection`.
⚠️ **Risk:** Without validation, an attacker could abuse the WAF detection functionality to make the worker send HTTP requests to internal IP addresses or arbitrary endpoints (SSRF).
🛡️ **Solution:** Imported and applied `isValidTargetUrl` from the security utils to validate `targetUrl`, matching the pattern established in other handlers.

---
*PR created automatically by Jules for task [12326214094484782341](https://jules.google.com/task/12326214094484782341) started by @SecH0us3*