### PR TITLE
🧪 improve tests: fix isValidTargetUrl missing IPv6 edge cases

### DIFF
--- a/app/src/utils/security.ts
+++ b/app/src/utils/security.ts
@@ -17,7 +17,14 @@ export function isValidTargetUrl(urlString: string): boolean {
 		const isIpv6 = hostname.startsWith('[') && hostname.endsWith(']');
 		const ipv6Normalized = isIpv6 ? hostname.slice(1, -1) : '';
 
+
+		// Block the unspecified address (::)
+		if (ipv6Normalized === '::') {
+			return false;
+		}
+
 		// Block IPv6 internal ranges
+
 		// Unique Local Address (fc00::/7)
 		if (ipv6Normalized.toLowerCase().startsWith('fc') || ipv6Normalized.toLowerCase().startsWith('fd')) {
 			return false;
@@ -32,7 +39,23 @@ export function isValidTargetUrl(urlString: string): boolean {
 			return false;
 		}
 
+
+		// Check for IPv4-compatible IPv6 (::0:0/96)
+		if (ipv6Normalized.toLowerCase().startsWith('::') && !ipv6Normalized.toLowerCase().startsWith('::ffff:') && ipv6Normalized !== '::1') {
+			// e.g. ::7f00:1
+			if (ipv6Normalized.toLowerCase().startsWith('::7f')) return false; // 127.0.0.0/8
+			if (ipv6Normalized.toLowerCase().startsWith('::0a') || ipv6Normalized.toLowerCase().startsWith('::a')) return false; // 10.0.0.0/8
+			if (ipv6Normalized.toLowerCase().startsWith('::ac')) {
+				// 172.16.0.0/12 -> ::ac10:0000 to ::ac1f:ffff
+				const match = ipv6Normalized.toLowerCase().match(/^::(ac[12][0-9a-f]|ac3[01])/);
+				if (match) return false;
+			}
+			if (ipv6Normalized.toLowerCase().startsWith('::c0a8')) return false; // 192.168.0.0/16
+			if (ipv6Normalized.toLowerCase().startsWith('::a9fe')) return false; // 169.254.0.0/16
+		}
+
 		// Check for IPv4-mapped IPv6 (::ffff:0:0/96)
+
 		if (ipv6Normalized.toLowerCase().startsWith('::ffff:')) {
 			const lastPart = ipv6Normalized.split(':').pop() || '';
 			if (lastPart.includes('.')) {

--- a/app/test/security.spec.ts
+++ b/app/test/security.spec.ts
@@ -69,6 +69,22 @@ describe('isValidTargetUrl', () => {
     });
 
     describe('IPv6 Internal Ranges (Current Gap)', () => {
+        it('should reject unspecified IPv6 address (::)', () => {
+            expect(isValidTargetUrl('http://[::]')).toBe(false);
+            expect(isValidTargetUrl('http://[0000:0000:0000:0000:0000:0000:0000:0000]')).toBe(false);
+        });
+
+        it('should reject IPv4-compatible IPv6 addresses for internal IPs', () => {
+            expect(isValidTargetUrl('http://[::127.0.0.1]')).toBe(false);
+            expect(isValidTargetUrl('http://[::10.0.0.1]')).toBe(false);
+            expect(isValidTargetUrl('http://[::192.168.0.1]')).toBe(false);
+        });
+
+        it('should reject uncompressed IPv6 loopback', () => {
+            expect(isValidTargetUrl('http://[0:0:0:0:0:0:0:1]')).toBe(false);
+            expect(isValidTargetUrl('http://[0000:0000:0000:0000:0000:0000:0000:0001]')).toBe(false);
+        });
+
         it('should reject IPv6 loopback', () => {
             expect(isValidTargetUrl('http://[::1]')).toBe(false);
         });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `isValidTargetUrl` utility had missing edge cases for parsing and blocking various representations of IPv6 internal ranges, specifically the unspecified address (`::`), IPv4-compatible IPv6 internal addresses (`[::127.0.0.1]`), and uncompressed IPv6 loopback addresses (`[0:0:0:0:0:0:0:1]`).

📊 **Coverage:** What scenarios are now tested
Added new test cases to `app/test/security.spec.ts` under the IPv6 edge cases block to verify that:
* The unspecified address `[::]` and `[0000:0000:0000:0000:0000:0000:0000:0000]` are blocked
* IPv4-compatible IPv6 addresses for internal IPs (`[::127.0.0.1]`, `[::10.0.0.1]`, `[::192.168.0.1]`) are correctly recognized and blocked
* Uncompressed or partially compressed loopbacks (`[0:0:0:0:0:0:0:1]`) are blocked (which Node's standard WHATWG URL parsing resolves to `[::1]`)

✨ **Result:** The improvement in test coverage
`app/src/utils/security.ts` has been refactored to explicitly block these IPv6 edge case formats. All edge cases successfully pass unit testing, improving internal SSRF validation.

---
*PR created automatically by Jules for task [10321767047687564553](https://jules.google.com/task/10321767047687564553) started by @SecH0us3*