### PR TITLE
🧪 Add test case for isValidTargetUrl catch block

### DIFF
--- a/app/test/security.spec.ts
+++ b/app/test/security.spec.ts
@@ -119,5 +119,9 @@ describe('isValidTargetUrl', () => {
             expect(isValidTargetUrl('not-a-url')).toBe(false);
             expect(isValidTargetUrl('')).toBe(false);
         });
+
+        it('should handle URLs that throw during parsing', () => {
+            expect(isValidTargetUrl('http://[::1')).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test coverage for the `catch` block in `isValidTargetUrl`.
📊 **Coverage:** A new test case for malformed URLs that throw during parsing (e.g., `http://[::1`) has been added.
✨ **Result:** Improved test reliability and 100% coverage for the `isValidTargetUrl` function's error handling path.

---
*PR created automatically by Jules for task [11184180611488052767](https://jules.google.com/task/11184180611488052767) started by @SecH0us3*