### PR TITLE
🔒 Fix prototype pollution vulnerability in substitutePayload

### DIFF
--- a/app/src/utils/payload-utils.ts
+++ b/app/src/utils/payload-utils.ts
@@ -9,6 +9,7 @@ export function substitutePayload(obj: any, payload: string): any {
 	} else if (obj && typeof obj === 'object') {
 		const result: any = {};
 		for (const [key, value] of Object.entries(obj)) {
+			if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
 			result[key] = substitutePayload(value, payload);
 		}
 		return result;

--- a/app/test/payload-utils.spec.ts
+++ b/app/test/payload-utils.spec.ts
@@ -97,6 +97,18 @@ describe('payload-utils', () => {
 			expect(substitutePayload(true, 'test')).toBe(true);
 			expect(substitutePayload(null, 'test')).toBe(null);
 		});
+
+		it('should prevent prototype pollution', () => {
+			const obj = JSON.parse('{"__proto__": {"polluted": "yes"}, "constructor": {"prototype": {"polluted": "yes"}}, "normal": "{PAYLOAD}"}');
+			const result = substitutePayload(obj, 'test');
+
+			expect(result.normal).toBe('test');
+			expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(false);
+			expect(Object.prototype.hasOwnProperty.call(result, 'constructor')).toBe(false);
+			expect(Object.prototype.hasOwnProperty.call(result, 'prototype')).toBe(false);
+			// @ts-ignore
+			expect({}.polluted).toBeUndefined();
+		});
 	});
 
 	describe('randomUppercase', () => {


### PR DESCRIPTION
🎯 **What:** Fixed a prototype pollution vulnerability in the `substitutePayload` function within `app/src/utils/payload-utils.ts`.

⚠️ **Risk:** The vulnerability allowed an attacker to supply a malicious JSON payload with keys like `__proto__`, `constructor`, or `prototype`, potentially modifying the prototype of all objects in the runtime environment. This could lead to a variety of security issues, including denial of service or remote code execution, depending on how polluted properties are accessed elsewhere in the application.

🛡️ **Solution:** Added a check `if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;` inside the `Object.entries` loop of `substitutePayload`. This ensures that malicious keys are skipped during object iteration, preventing them from polluting the prototype chain. Also, added a unit test in `app/test/payload-utils.spec.ts` to assert that the prototype pollution keys are successfully ignored by the function.

---
*PR created automatically by Jules for task [7072109747886822289](https://jules.google.com/task/7072109747886822289) started by @SecH0us3*