### PR TITLE
feat: add DDoS-Guard WAF detection signature

### DIFF
--- a/packages/core/src/waf-detection.ts
+++ b/packages/core/src/waf-detection.ts
@@ -218,6 +218,13 @@ export class WAFDetector {
 				'Request method variations',
 				'Content-Type manipulation',
 			],
+			'DDoS-Guard': [
+				'HTTP parameter pollution',
+				'Double URL encoding',
+				'Request rate pacing',
+				'Header case manipulation',
+				'Alternative whitespace characters',
+			],
 			Imperva: ['Parameter pollution', 'HTTP verb tampering', 'Custom header injection', 'Encoding combinations'],
 			'F5 BIG-IP': ['Request smuggling techniques', 'HTTP/1.0 downgrade', 'Custom User-Agent strings'],
 			ModSecurity: ['Comment-based SQL obfuscation', 'Case sensitivity exploits', 'Regex pattern bypasses', 'Alternative operators'],

--- a/packages/core/src/waf-signatures.ts
+++ b/packages/core/src/waf-signatures.ts
@@ -50,6 +50,17 @@ export const WAF_SIGNATURES: WAFSignature[] = [
 		bodyPatterns: [/AWS WAF/i],
 	},
 
+	// DDoS-Guard
+	{
+		name: 'DDoS-Guard',
+		headers: {
+			server: /ddos-guard/i,
+		},
+		cookiePatterns: [/__ddg1_/i, /__ddg2_/i, /__ddg5_/i],
+		statusCodes: [403, 429],
+		bodyPatterns: [/ddos-guard/i, /ddg-captcha/i],
+	},
+
 	// Imperva/Incapsula
 	{
 		name: 'Imperva',

--- a/packages/core/src/waf-signatures.ts
+++ b/packages/core/src/waf-signatures.ts
@@ -56,7 +56,7 @@ export const WAF_SIGNATURES: WAFSignature[] = [
 		headers: {
 			server: /ddos-guard/i,
 		},
-		cookiePatterns: [/__ddg1_/i, /__ddg2_/i, /__ddg5_/i],
+		cookiePatterns: [/__ddg1_/i, /__ddg2_/i, /__ddg5_/i, /__ddgid/i, /__ddgmark/i],
 		statusCodes: [403, 429],
 		bodyPatterns: [/ddos-guard/i, /ddg-captcha/i],
 	},

--- a/packages/core/test/waf-detection.spec.ts
+++ b/packages/core/test/waf-detection.spec.ts
@@ -6,6 +6,7 @@ describe('WAFDetector', () => {
 		const wafs = WAFDetector.getSupportedWafs();
 		expect(wafs).toContain('Cloudflare');
 		expect(wafs).toContain('AWS WAF');
+		expect(wafs).toContain('DDoS-Guard');
 		expect(wafs).toContain('Signal Sciences');
 		expect(wafs).not.toContain('Generic WAF'); // Generic should be filtered out
 	});
@@ -25,6 +26,26 @@ describe('WAFDetector', () => {
 		const result = await WAFDetector.detectFromResponse(mockResponse);
 		expect(result.detected).toBe(true);
 		expect(result.wafType).toBe('Cloudflare');
+		expect(result.confidence).toBeGreaterThan(40);
+		expect(result.evidence.length).toBeGreaterThan(0);
+		expect(result.suggestedBypassTechniques.length).toBeGreaterThan(0);
+	});
+
+	it('should detect DDoS-Guard WAF from headers and cookies', async () => {
+		const mockResponse = {
+			status: 403,
+			headers: {
+				get: (name: string) => {
+					if (name.toLowerCase() === 'server') return 'ddos-guard';
+					if (name.toLowerCase() === 'set-cookie') return '__ddg1_=abc123; Path=/';
+					return null;
+				},
+			},
+		} as unknown as Response;
+
+		const result = await WAFDetector.detectFromResponse(mockResponse);
+		expect(result.detected).toBe(true);
+		expect(result.wafType).toBe('DDoS-Guard');
 		expect(result.confidence).toBeGreaterThan(40);
 		expect(result.evidence.length).toBeGreaterThan(0);
 		expect(result.suggestedBypassTechniques.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Description

Adds detection signatures for **DDoS-Guard** (L7 Web Application Firewall and DDoS mitigation provider).

### Changes
- Added `DDoS-Guard` entry to `WAF_SIGNATURES` in `packages/core/src/waf-signatures.ts`:
  - **Headers**: `server: /ddos-guard/i`
  - **Cookies**: `/__ddg1_/i`, `/__ddg2_/i`, `/__ddg5_/i`
  - **Status codes**: `403`, `429`
  - **Body patterns**: `/ddos-guard/i`, `/ddg-captcha/i`

### Verification
- All existing core and worker tests passing via `npm test`.