### PR TITLE
chore(release): bump version to v1.1.0 and add padding input to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
     description: 'Run HTTP manipulation tests (true/false)'
     required: false
     default: 'false'
+  padding:
+    description: 'Enable WAF inspection buffer padding evasion (8kb, 16kb, 64kb, 128kb)'
+    required: false
   sarif-output:
     description: 'Path to save SARIF report (e.g., "waf-results.sarif")'
     required: false
@@ -95,6 +98,7 @@ runs:
         INPUT_AUTO_DETECT: ${{ inputs.auto-detect }}
         INPUT_ENCODING: ${{ inputs.encoding }}
         INPUT_HTTP_MANIPULATION: ${{ inputs.http-manipulation }}
+        INPUT_PADDING: ${{ inputs.padding }}
         INPUT_FAIL_ON_BYPASS: ${{ inputs.fail-on-bypass }}
         INPUT_THRESHOLD: ${{ inputs.threshold }}
         INPUT_SUMMARY_OUTPUT: ${{ inputs.summary-output }}
@@ -139,6 +143,10 @@ runs:
 
         if [ "$INPUT_HTTP_MANIPULATION" = "true" ]; then
           ARGS+=("--http-manipulation")
+        fi
+
+        if [ -n "$INPUT_PADDING" ]; then
+          ARGS+=("--padding" "$INPUT_PADDING")
         fi
 
         if [ "$INPUT_FAIL_ON_BYPASS" = "true" ]; then

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waf-checker/cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bin": "./dist/index.js",
   "scripts": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,7 +46,7 @@ const program = new Command();
 program
 	.name('waf-checker')
 	.description('WAF Security Testing Tool (CLI version)')
-	.version('1.0.0')
+	.version('1.1.0')
 	.showHelpAfterError()
 	.option('--no-color', 'Disable colored output')
 	.addHelpText('after', detailedHelp);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waf-checker/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Release v1.1.0

### Summary of Changes
- Added `padding` input to `action.yml` for configuring WAF inspection buffer padding evasion in GitHub Actions workflows.
- Bumped version to `1.1.0` in `@waf-checker/core`, `@waf-checker/cli`, and CLI executable.
- All workspace tests passing.