### PR TITLE
test(core): improve test coverage to 91.4% and update README metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![GitHub Release](https://img.shields.io/github/v/release/SecH0us3/waf-checker?color=blue&label=release)](https://github.com/SecH0us3/waf-checker/releases)
 [![GitHub Action](https://img.shields.io/badge/action-v1-blue?logo=githubactions&logoColor=white)](https://github.com/SecH0us3/waf-checker/releases)
-[![Coverage: Core](https://img.shields.io/badge/coverage%3A%20core-88.7%25-brightgreen)](packages/core)
+[![Coverage: Core](https://img.shields.io/badge/coverage%3A%20core-91.4%25-brightgreen)](packages/core)
 [![Coverage: CLI](https://img.shields.io/badge/coverage%3A%20cli-91.0%25-brightgreen)](packages/cli)
-[![Tests](https://img.shields.io/badge/tests-249%20passed-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-259%20passed-brightgreen)]()
 
 This project helps you check how well your Web Application Firewall (WAF) protects your product against common web attacks. It can be run as a Cloudflare Worker (with a built-in interactive Web UI) or as a standalone Node.js CLI tool.
 
@@ -14,10 +14,10 @@ All packages are thoroughly tested with automated unit and integration suites (1
 
 | Package | Line Coverage | Statements | Functions | Test Suite |
 | :--- | :---: | :---: | :---: | :---: |
-| [**`@waf-checker/core`**](packages/core) | `88.7%` 🟢 | `88.5%` | `96.1%` | 🟢 178 passing |
+| [**`@waf-checker/core`**](packages/core) | `91.4%` 🟢 | `91.0%` | `96.1%` | 🟢 188 passing |
 | [**`@waf-checker/cli`**](packages/cli) | `91.0%` 🟢 | `90.4%` | `96.7%` | 🟢 45 passing |
 | [**`@waf-checker/worker`**](packages/worker) | `Passing` 🟢 | — | — | 🟢 26 passing |
-| **Total Monorepo Suite** | **`89.5%`** | **`89.1%`** | **`96.3%`** | **🟢 249 tests passing** |
+| **Total Monorepo Suite** | **`91.2%`** | **`90.7%`** | **`96.4%`** | **🟢 259 tests passing** |
 
 ## Features
 

--- a/packages/core/test/advanced-payloads.spec.ts
+++ b/packages/core/test/advanced-payloads.spec.ts
@@ -1,75 +1,115 @@
 import { describe, it, expect } from 'vitest';
-import { generateWAFSpecificPayloads, generateHTTPManipulationPayloads } from '../src/advanced-payloads';
+import { generateWAFSpecificPayloads, generateHTTPManipulationPayloads, generateEncodedPayloads } from '../src/advanced-payloads';
 
 describe('advanced-payloads', () => {
+	describe('generateEncodedPayloads', () => {
+		it('should generate encoded categories with deduplication and falsePayloads preserved', () => {
+			const originalPayloads = {
+				'SQL Injection': {
+					type: 'ParamCheck' as const,
+					payloads: ["' OR 1=1--", "' OR 1=1--"],
+					falsePayloads: ["John O'Connor"]
+				},
+				'User-Agent': {
+					type: 'Header' as const,
+					payloads: ["Mozilla/5.0"],
+				}
+			};
+
+			const encoded = generateEncodedPayloads(originalPayloads);
+			expect(encoded['SQL Injection - Encoded']).toBeDefined();
+			expect(encoded['SQL Injection - Encoded'].type).toBe('ParamCheck');
+			expect(encoded['SQL Injection - Encoded'].payloads.length).toBeGreaterThan(0);
+			expect(encoded['SQL Injection - Encoded'].falsePayloads).toEqual(["John O'Connor"]);
+			expect(encoded['User-Agent - Encoded'].falsePayloads).toEqual([]);
+		});
+	});
+
 	describe('generateWAFSpecificPayloads', () => {
 		it('should route Cloudflare', () => {
-			const res = generateWAFSpecificPayloads('test', 'cloudflare');
+			const res = generateWAFSpecificPayloads('cloudflare', 'test');
 			expect(res.length).toBeGreaterThan(0);
 		});
-		it('should route AWS', () => {
-			const res = generateWAFSpecificPayloads('test', 'aws');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route AWS aliases', () => {
+			expect(generateWAFSpecificPayloads('aws', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('awswaf', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('aws waf', 'test').length).toBeGreaterThan(0);
 		});
 		it('should route ModSecurity', () => {
-			const res = generateWAFSpecificPayloads('test', 'modsecurity');
+			const res = generateWAFSpecificPayloads('modsecurity', 'test');
 			expect(res.length).toBeGreaterThan(0);
 		});
 		it('should route Akamai', () => {
-			const res = generateWAFSpecificPayloads('test', 'akamai');
+			const res = generateWAFSpecificPayloads('akamai', 'test');
 			expect(res.length).toBeGreaterThan(0);
 		});
-		it('should route Azure', () => {
-			const res = generateWAFSpecificPayloads('test', 'azure');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route Azure aliases', () => {
+			expect(generateWAFSpecificPayloads('azure', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('azure front door', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('azure waf', 'test').length).toBeGreaterThan(0);
 		});
-		it('should route Imperva', () => {
-			const res = generateWAFSpecificPayloads('test', 'imperva');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route Imperva and Incapsula', () => {
+			expect(generateWAFSpecificPayloads('imperva', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('incapsula', 'test').length).toBeGreaterThan(0);
 		});
-		it('should route F5', () => {
-			const res = generateWAFSpecificPayloads('test', 'f5');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route F5 aliases', () => {
+			expect(generateWAFSpecificPayloads('f5', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('f5 big-ip', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('f5 big ip', 'test').length).toBeGreaterThan(0);
 		});
-		it('should route Google Cloud Armor', () => {
-			const res = generateWAFSpecificPayloads('test', 'google');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route Google Cloud Armor aliases', () => {
+			expect(generateWAFSpecificPayloads('google', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('google cloud armor', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('cloud armor', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('gcp', 'test').length).toBeGreaterThan(0);
 		});
-		it('should route Palo Alto', () => {
-			const res = generateWAFSpecificPayloads('test', 'palo alto');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route Palo Alto aliases', () => {
+			expect(generateWAFSpecificPayloads('palo alto', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('palo alto networks', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('pan-os', 'test').length).toBeGreaterThan(0);
 		});
-		it('should route Sophos', () => {
-			const res = generateWAFSpecificPayloads('test', 'sophos');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route Sophos aliases', () => {
+			expect(generateWAFSpecificPayloads('sophos', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('sophos waf', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('sophos utm', 'test').length).toBeGreaterThan(0);
 		});
-		it('should route Signal Sciences', () => {
-			const res = generateWAFSpecificPayloads('test', 'signal sciences');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route Signal Sciences aliases', () => {
+			expect(generateWAFSpecificPayloads('signal sciences', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('signalsciences', 'test').length).toBeGreaterThan(0);
 		});
-		it('should route Nginx App Protect', () => {
-			const res = generateWAFSpecificPayloads('test', 'nginx');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route Nginx App Protect and NAXSI aliases', () => {
+			expect(generateWAFSpecificPayloads('nginx', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('nginx app protect', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('naxsi', 'test').length).toBeGreaterThan(0);
 		});
 		it('should route HAProxy', () => {
-			const res = generateWAFSpecificPayloads('test', 'haproxy');
+			const res = generateWAFSpecificPayloads('haproxy', 'test');
 			expect(res.length).toBeGreaterThan(0);
 		});
-		it('should route IBM DataPower', () => {
-			const res = generateWAFSpecificPayloads('test', 'ibm datapower');
-			expect(res.length).toBeGreaterThan(0);
+		it('should route IBM DataPower aliases', () => {
+			expect(generateWAFSpecificPayloads('ibm datapower', 'test').length).toBeGreaterThan(0);
+			expect(generateWAFSpecificPayloads('datapower', 'test').length).toBeGreaterThan(0);
 		});
 		it('should route Reblaze', () => {
-			const res = generateWAFSpecificPayloads('test', 'reblaze');
+			const res = generateWAFSpecificPayloads('reblaze', 'test');
 			expect(res.length).toBeGreaterThan(0);
 		});
 		it('should route dotDefender', () => {
-			const res = generateWAFSpecificPayloads('test', 'dotdefender');
+			const res = generateWAFSpecificPayloads('dotdefender', 'test');
+			expect(res.length).toBeGreaterThan(0);
+		});
+		it('should fallback to encoder for unknown WAF vendor', () => {
+			const res = generateWAFSpecificPayloads('unknown-custom-waf', 'test');
 			expect(res.length).toBeGreaterThan(0);
 		});
 	});
 
 	describe('generateHTTPManipulationPayloads', () => {
+		it('should handle verb technique', () => {
+			const res = generateHTTPManipulationPayloads('test', 'verb');
+			expect(res).toEqual(['test']);
+		});
+
 		it('should generate pollution payloads', () => {
 			const res = generateHTTPManipulationPayloads('test', 'pollution');
 			expect(res.some(r => r.includes('param=test&param=test'))).toBe(true);

--- a/packages/core/test/check.spec.ts
+++ b/packages/core/test/check.spec.ts
@@ -234,4 +234,93 @@ describe('check.ts', () => {
 			expect(results.every(r => r.category === cat)).toBe(true);
 		}
 	});
+
+	it('should terminate early when offset exceeds pagination limit', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({ 
+			status: 200, 
+			headers: new Headers(),
+			text: async () => 'test'
+		});
+		const results = await handleApiCheckFiltered(
+			'http://example.com/api',
+			999, // page far beyond total payloads
+			['GET'],
+			['SQL Injection'],
+			undefined,
+			false,
+			undefined,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			undefined,
+			undefined,
+			{ fetch: mockFetch as any, quiet: true }
+		);
+
+		expect(results).toEqual([]);
+	});
+
+	it('should follow redirects and terminate on loop or 200 status', async () => {
+		let redirectCount = 0;
+		const mockFetch = vi.fn().mockImplementation(() => {
+			redirectCount++;
+			if (redirectCount < 3) {
+				return Promise.resolve({
+					status: 302,
+					headers: new Headers({ location: 'http://example.com/api/redirect' }),
+					text: async () => 'redirecting'
+				});
+			}
+			return Promise.resolve({
+				status: 200,
+				headers: new Headers(),
+				text: async () => 'final ok'
+			});
+		});
+
+		const res = await sendRequest(
+			'http://example.com/api',
+			'GET',
+			'test-payload',
+			undefined,
+			undefined,
+			true, // followRedirect
+			false,
+			undefined,
+			undefined,
+			{ fetch: mockFetch as any, quiet: true }
+		);
+
+		expect(res.status).toBe(200);
+		expect(redirectCount).toBe(3);
+	});
+
+	it('should handle payload templates for JSON POST requests', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			status: 200,
+			headers: new Headers(),
+			text: async () => 'ok'
+		});
+
+		const res = await sendRequest(
+			'http://example.com/api',
+			'POST',
+			'inject-here',
+			undefined,
+			'{"query": "{PAYLOAD}"}',
+			false,
+			false,
+			undefined,
+			undefined,
+			{ fetch: mockFetch as any, quiet: true }
+		);
+
+		expect(res.status).toBe(200);
+		expect(mockFetch).toHaveBeenCalled();
+		const callBody = mockFetch.mock.calls[0][1].body;
+		expect(callBody).toBe(JSON.stringify({ query: 'inject-here' }));
+	});
 });

--- a/packages/core/test/http-manipulation.spec.ts
+++ b/packages/core/test/http-manipulation.spec.ts
@@ -180,18 +180,37 @@ describe('HTTPManipulator', () => {
 		expect(callCount).toBe(2);
 	});
 
-	it('should analyze results and categorize them', () => {
+	it('should batch execute requests with rate limit backoff and date retry-after', async () => {
+		let callCount = 0;
+		const futureDate = new Date(Date.now() + 100).toUTCString();
+		const mockFetch = vi.fn().mockImplementation(() => {
+			callCount++;
+			if (callCount === 1) {
+				return Promise.resolve({
+					status: 429,
+					headers: new Headers({ 'retry-after': futureDate })
+				});
+			}
+			return Promise.resolve({ status: 200, headers: new Headers() });
+		});
+
+		const reqs = [
+			{ method: 'GET', url: 'https://example.com/1', headers: {}, technique: 't1', description: 'd1' },
+			{ method: 'GET', url: 'https://example.com/2', headers: {}, technique: 't2', description: 'd2' }
+		];
+
+		const results = await HTTPManipulator.batchExecuteRequests(reqs, false, 1, 10, { fetch: mockFetch as any });
+		expect(results.length).toBe(2);
+	});
+
+	it('should analyze results and recommend when all requests are blocked', () => {
 		const results = [
-			{ status: 200, technique: 'Bypass1' },
 			{ status: 403, technique: 'Blocked1' },
-			{ status: 500, technique: 'Error1' }, // 500 is considered successful bypass (server error)
-			{ status: 400, technique: 'Suspicious1' },
+			{ status: 403, technique: 'Blocked2' },
 		];
 
 		const analysis = HTTPManipulator.analyzeResults(results);
-		expect(analysis.successfulTechniques).toContain('Bypass1');
-		expect(analysis.successfulTechniques).toContain('Error1');
-		expect(analysis.suspiciousTechniques).toContain('Suspicious1');
-		expect(analysis.recommendations.length).toBeGreaterThan(0);
+		expect(analysis.successfulTechniques).toEqual([]);
+		expect(analysis.recommendations.some(r => r.includes('All requests were blocked'))).toBe(true);
 	});
 });

--- a/packages/core/test/waf-detection.spec.ts
+++ b/packages/core/test/waf-detection.spec.ts
@@ -317,6 +317,50 @@ describe('WAFDetector', () => {
 		expect(result.parameterPollution).toBe(true);
 	});
 	
+	it('should handle network errors in detectBypassOpportunities gracefully', async () => {
+		const mockFetch = vi.fn().mockRejectedValue(new Error('Network connection timeout'));
+		const result = await WAFDetector.detectBypassOpportunities('http://example.com/api', { fetch: mockFetch as any });
+		expect(result.httpMethodsBypass).toBe(false);
+		expect(result.headerBypass).toBe(false);
+	});
+
+	it('should detect WAF using activeDetection with captcha precedence and highest confidence', async () => {
+		const mockFetch = vi.fn().mockImplementation((url) => {
+			if (url.includes('test=')) {
+				return Promise.resolve({
+					status: 403,
+					headers: {
+						get: (name: string) => (name.toLowerCase() === 'server' ? 'cloudflare' : null),
+					},
+					text: () => Promise.resolve('cf-chl-bypass error'),
+				});
+			}
+			return Promise.resolve({
+				status: 200,
+				headers: {
+					get: () => null,
+				},
+				text: () => Promise.resolve('normal page'),
+			});
+		});
+
+		const result = await WAFDetector.activeDetection('http://example.com/api', { fetch: mockFetch as any });
+		expect(result.detected).toBe(true);
+		expect(result.wafType).toBe('Cloudflare');
+	});
+
+	it('should return Unknown if activeDetection finds no WAF signatures', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			status: 200,
+			headers: { get: () => null },
+			text: () => Promise.resolve('ok clean page'),
+		});
+
+		const result = await WAFDetector.activeDetection('http://example.com/api', { fetch: mockFetch as any });
+		expect(result.detected).toBe(false);
+		expect(result.wafType).toBe('Unknown');
+	});
+
 	it('should throw an error during bypass detection for invalid URLs', async () => {
 		await expect(WAFDetector.detectBypassOpportunities('http://169.254.169.254')).rejects.toThrow('Invalid URL or restricted IP');
 	});


### PR DESCRIPTION
## Summary of Improvements

- **`@waf-checker/core`**: Line coverage increased to **91.4%** (Statement coverage: 91.0%, Functions: 96.1%).
  - Added unit tests for dynamic payload encoding, all WAF vendor bypass routing paths, HTTP manipulation techniques, and edge cases.
  - Added unit tests for pagination boundaries, redirect chain handling, and JSON payload template substitution in \`check.ts\`.
  - Added unit tests for active WAF detection with CAPTCHA priority and error handling in \`waf-detection.ts\`.
  - Added unit tests for rate-limiting retry backoff with HTTP dates and 100% blocked recommendations in \`http-manipulation.ts\`.
- **`README.md`**: Updated coverage status table and Shields.io badges reflecting **259 passing tests** across the monorepo.