### PR TITLE
fix(worker): define responseTime in renderReport results loop

### DIFF
--- a/packages/worker/src/static/main.js
+++ b/packages/worker/src/static/main.js
@@ -97,6 +97,7 @@ function renderReport(results, falsePositiveMode = false) {
 		}
 		const isBypass = (r.status == 200 || r.status == '200') && !falsePositiveMode;
 		const patchBtn = isBypass ? `<button type="button" class="btn btn-sm btn-outline-danger py-0 px-1 ms-2" style="font-size:0.7rem;" onclick="showVirtualPatchModal()" title="Remediate this bypass">🛡️ Patch</button>` : '';
+		const responseTime = r.responseTime || 0;
 		html +=
 			`<tr data-status='${r.status}'>` +
 			`<td>${r.category}</td>` +

--- a/packages/worker/test/index.spec.ts
+++ b/packages/worker/test/index.spec.ts
@@ -141,4 +141,28 @@ describe('WAF Checker API', () => {
 		const data = await response.json();
 		expect(data.error).toBe('Invalid URL or restricted IP');
 	});
+
+	it('serves main.js and renderReport renders table with responseTime without errors', async () => {
+		const response = await SELF.fetch('https://example.com/main.js');
+		expect(response.status).toBe(200);
+		const code = await response.text();
+
+		const sandbox = {
+			window: {} as any,
+			document: {
+				querySelectorAll: () => [],
+				getElementById: () => null,
+				addEventListener: () => {},
+				createElement: () => ({ set textContent(v: string) { (this as any)._v = v; }, get innerHTML() { return (this as any)._v; } }),
+			} as any,
+			setTimeout: (fn: Function) => fn(),
+		};
+		const fn = new Function('window', 'document', 'setTimeout', code + '\nreturn renderReport;');
+		const renderReport = fn(sandbox.window, sandbox.document, sandbox.setTimeout);
+		const html = renderReport([
+			{ category: 'SQL Injection', method: 'GET', payload: 'union select', status: 200, responseTime: 120 }
+		], false);
+		expect(html).toContain('120ms');
+		expect(html).toContain('🛡️ Patch');
+	});
 });


### PR DESCRIPTION
## Summary

Fixes `ReferenceError: responseTime is not defined` thrown at `renderReport` in `packages/worker/src/static/main.js`.

### Root Cause:
During the addition of the inline `🛡️ Patch` button, the `const responseTime = r.responseTime || 0;` declaration inside the results rendering loop in `renderReport` was inadvertently displaced, causing table rendering to fail with `ReferenceError: responseTime is not defined`.

### Changes:
1. Re-introduced `const responseTime = r.responseTime || 0;` in `packages/worker/src/static/main.js`.
2. Added unit test in `packages/worker/test/index.spec.ts` that fetches `/main.js` and evaluates `renderReport` in an isolated sandbox, ensuring it parses, executes, and outputs the response time and patch buttons without throwing errors.