### PR TITLE
feat(virtual-patch): add support for WAF misses and 404 remediation

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -185,6 +185,7 @@ checkCmd
 	.option('--patch-tier <tier>', 'Defense tier: strict (exact token), heuristic (regex pattern), or both', 'both')
 	.option('--patch-action <action>', 'Rule action: block or simulate', 'block')
 	.option('--patch-scope', 'Scope virtual patches to the target URL path', false)
+	.option('--patch-include-misses', 'Include 404 Not Found and 5xx origin responses in virtual patch generation', false)
 	.option('-q, --quiet', 'Suppress per-request logging, displaying only final results')
 	.option('--silent', 'Alias for --quiet')
 	.option('--fail-on-bypass', 'Exit with exit code 1 if any bypasses are detected', false)
@@ -245,6 +246,7 @@ checkCmd
 					tier: options.patchTier as PatchTier,
 					action: options.patchAction as PatchAction,
 					scopeToPath: Boolean(options.patchScope),
+					includeMisses: Boolean(options.patchIncludeMisses),
 					targetUrl: url,
 				});
 
@@ -603,6 +605,7 @@ program
 	.option('-a, --action <action>', 'Rule action: block or simulate', 'block')
 	.option('-o, --output <path>', 'Output file or directory to write patches to')
 	.option('--scope-to-path', 'Scope rules to target URL path if present in report', false)
+	.option('--include-misses', 'Include 404 Not Found and 5xx origin responses in virtual patch generation', false)
 	.option('--json', 'Output patch report in JSON format', false)
 	.action(async (file: string, options: any) => {
 		try {
@@ -622,6 +625,7 @@ program
 				tier: options.tier as PatchTier,
 				action: options.action as PatchAction,
 				scopeToPath: Boolean(options.scopeToPath),
+				includeMisses: Boolean(options.includeMisses),
 				targetUrl,
 			});
 

--- a/packages/cli/src/reports/markdown.ts
+++ b/packages/cli/src/reports/markdown.ts
@@ -9,6 +9,7 @@ export function generateMarkdownReport(
 ): string {
 	let blocked = 0;
 	let bypassed = 0;
+	let misses = 0;
 	let errors = 0;
 	let other = 0;
 	let detectedWAF = 'Unknown';
@@ -21,6 +22,8 @@ export function generateMarkdownReport(
 			blocked++;
 		} else if (r.status === 200 || r.status === '200') {
 			bypassed++;
+		} else if (r.status === 404 || r.status === '404') {
+			misses++;
 		} else if (r.status === 'ERR' || r.status === 500 || r.status === '500') {
 			errors++;
 		} else {
@@ -32,15 +35,17 @@ export function generateMarkdownReport(
 	const protectionScore = total > 0 ? Math.round((blocked / total) * 100) : 100;
 
 	// Calculate per-category stats
-	const categoryMap = new Map<string, { total: number; blocked: number; bypassed: number; errors: number }>();
+	const categoryMap = new Map<string, { total: number; blocked: number; bypassed: number; misses: number; errors: number }>();
 
 	for (const r of results) {
-		const entry = categoryMap.get(r.category) || { total: 0, blocked: 0, bypassed: 0, errors: 0 };
+		const entry = categoryMap.get(r.category) || { total: 0, blocked: 0, bypassed: 0, misses: 0, errors: 0 };
 		entry.total++;
 		if (r.status === 403 || r.status === '403' || r.status === 'BLOCKED') {
 			entry.blocked++;
 		} else if (r.status === 200 || r.status === '200') {
 			entry.bypassed++;
+		} else if (r.status === 404 || r.status === '404') {
+			entry.misses++;
 		} else {
 			entry.errors++;
 		}
@@ -48,6 +53,7 @@ export function generateMarkdownReport(
 	}
 
 	const bypassedItems = results.filter((r) => r.status === 200 || r.status === '200');
+	const missedItems = results.filter((r) => r.status === 404 || r.status === '404');
 
 	// Status badge
 	const scoreEmoji = protectionScore >= 90 ? '🟢' : protectionScore >= 70 ? '🟡' : '🔴';
@@ -73,25 +79,26 @@ export function generateMarkdownReport(
 		`| :--- | :--- | :--- |`,
 		`| 🎯 **Total Tests** | \`${total}\` | \`100%\` |`,
 		`| 🛡️ **Blocked (Protected)** | \`${blocked}\` | \`${total > 0 ? Math.round((blocked / total) * 100) : 0}%\` |`,
-		`| ⚠️ **Bypassed (Vulnerable)** | \`${bypassed}\` | \`${total > 0 ? Math.round((bypassed / total) * 100) : 0}%\` |`,
+		`| 🔴 **Critical Bypasses (200 OK)** | \`${bypassed}\` | \`${total > 0 ? Math.round((bypassed / total) * 100) : 0}%\` |`,
+		`| ⚠️ **WAF Misses (Unprotected 404)** | \`${misses}\` | \`${total > 0 ? Math.round((misses / total) * 100) : 0}%\` |`,
 		`| ❓ **Errors / Other** | \`${errors + other}\` | \`${total > 0 ? Math.round(((errors + other) / total) * 100) : 0}%\` |`,
 		``,
 		`### 📊 Attack Category Breakdown`,
 		``,
-		`| Attack Category | Total | Blocked | Bypassed | Protection Rate |`,
-		`| :--- | :--- | :--- | :--- | :--- |`,
+		`| Attack Category | Total | Blocked | Bypasses (200) | Misses (404) | Protection Rate |`,
+		`| :--- | :--- | :--- | :--- | :--- | :--- |`,
 	];
 
 	for (const [cat, data] of categoryMap.entries()) {
 		const rate = data.total > 0 ? Math.round((data.blocked / data.total) * 100) : 100;
 		const catEmoji = rate >= 90 ? '🟢' : rate >= 70 ? '🟡' : '🔴';
-		lines.push(`| **${cat}** | \`${data.total}\` | \`${data.blocked}\` | \`${data.bypassed}\` | ${catEmoji} \`${rate}%\` |`);
+		lines.push(`| **${cat}** | \`${data.total}\` | \`${data.blocked}\` | \`${data.bypassed}\` | \`${data.misses}\` | ${catEmoji} \`${rate}%\` |`);
 	}
 
 	lines.push(``);
 
 	if (bypassedItems.length > 0) {
-		lines.push(`### ⚠️ Bypassed Payloads (${bypassedItems.length})`);
+		lines.push(`### 🔴 Critical Bypassed Payloads (200 OK) (${bypassedItems.length})`);
 		lines.push(``);
 		lines.push(`<details>`);
 		lines.push(`<summary><b>Click to inspect ${bypassedItems.length} bypassed attack vectors</b></summary>`);
@@ -117,7 +124,37 @@ export function generateMarkdownReport(
 		lines.push(`</details>`);
 	} else {
 		lines.push(`### ✅ No Bypasses Detected`);
-		lines.push(`All executed attack payloads were successfully blocked by the WAF.`);
+		lines.push(`No attack payloads yielded active 200 OK responses.`);
+	}
+
+	if (missedItems.length > 0) {
+		lines.push(``);
+		lines.push(`### ⚠️ WAF Misses / Origin Responses (404 Not Found) (${missedItems.length})`);
+		lines.push(``);
+		lines.push(`<details>`);
+		lines.push(`<summary><b>Click to inspect ${missedItems.length} unprotected vectors (Status 404)</b></summary>`);
+		lines.push(``);
+		lines.push(`> **Note:** These requests bypassed perimeter WAF inspection and reached the origin server (returning 404 Not Found). Consider adding virtual patches to block these attack patterns on the WAF level.`);
+		lines.push(``);
+		lines.push(`| Category | Method | Status | Time | Payload |`);
+		lines.push(`| :--- | :--- | :--- | :--- | :--- |`);
+
+		for (const item of missedItems) {
+			const safePayload = item.payload
+				.replace(/&/g, '&amp;')
+				.replace(/</g, '&lt;')
+				.replace(/>/g, '&gt;')
+				.replace(/"/g, '&quot;')
+				.replace(/'/g, '&#39;')
+				.replace(/\|/g, '&#124;')
+				.replace(/\r?\n/g, ' ');
+			lines.push(
+				`| \`${item.category}\` | \`${item.method}\` | \`${item.status}\` | \`${item.responseTime}ms\` | <code>${safePayload}</code> |`,
+			);
+		}
+
+		lines.push(``);
+		lines.push(`</details>`);
 	}
 
 	if (reverseEngineering) {

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -780,5 +780,34 @@ describe('CLI Argument Processing', () => {
 
 			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('No bypasses detected'));
 		});
+
+		it('should generate patches for 404 responses when --include-misses is specified in patch command', async () => {
+			vi.mocked(fs.existsSync).mockReturnValueOnce(true);
+			vi.mocked(fs.readFileSync).mockReturnValueOnce(
+				JSON.stringify([
+					{
+						category: 'Sensitive Files',
+						method: 'GET',
+						payload: '/.git/config',
+						status: 404,
+						responseTime: 40,
+					},
+				])
+			);
+
+			await expect(
+				program.parseAsync([
+					'node',
+					'index.js',
+					'patch',
+					'report.json',
+					'--include-misses',
+					'--waf',
+					'cloudflare',
+				])
+			).resolves.toBeDefined();
+
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('CLOUDFLARE'));
+		});
 	});
 });

--- a/packages/core/src/virtual-patch/heuristics.ts
+++ b/packages/core/src/virtual-patch/heuristics.ts
@@ -120,7 +120,7 @@ export const CATEGORY_HEURISTICS: Record<string, CategoryHeuristic> = {
 		defaultLocation: 'query',
 	},
 	'Sensitive Files': {
-		pattern: `(?i)(?:\\.(?:env|git|svn|hg|ds_store|bak|old|swp|config|yml|yaml|sql|tar\\.gz|zip)$)`,
+		pattern: `(?i)(?:\\.(?:env|git|svn|hg|ds_store|bak|old|swp|config|yml|yaml|sql|tar\\.gz|zip)(?:$|[/?#])|/\\.(?:git|env|svn|hg)(?:/|$|\\w))`,
 		description: 'Detects path requests probing for exposed source repositories, environment files, and backups',
 		defaultLocation: 'uri',
 	},

--- a/packages/core/src/virtual-patch/index.ts
+++ b/packages/core/src/virtual-patch/index.ts
@@ -19,9 +19,23 @@ export * from './generators/modsecurity';
 export * from './generators/nginx';
 
 /**
- * Filters audit results to isolate confirmed WAF bypasses (HTTP 200).
+ * Filters audit results to isolate confirmed WAF bypasses (HTTP 200)
+ * and optionally WAF misses (e.g. 404 Not Found, 5xx Server Errors).
  */
-export function filterBypasses(results: AuditResultItem[]): AuditResultItem[] {
+export function filterBypasses(
+	results: AuditResultItem[],
+	options: { includeMisses?: boolean; statusCodes?: number[] } = {}
+): AuditResultItem[] {
+	if (options.statusCodes && options.statusCodes.length > 0) {
+		const set = new Set(options.statusCodes.map(String));
+		return results.filter((r) => set.has(String(r.status)));
+	}
+	if (options.includeMisses) {
+		return results.filter((r) => {
+			const s = parseInt(String(r.status), 10);
+			return s === 200 || s === 404 || (s >= 500 && s < 600);
+		});
+	}
 	return results.filter((r) => r.status === 200 || r.status === '200');
 }
 
@@ -33,7 +47,7 @@ export function generateVirtualPatches(
 	results: AuditResultItem[],
 	options: VirtualPatchOptions = {}
 ): VirtualPatchReport {
-	const bypasses = filterBypasses(results);
+	const bypasses = filterBypasses(results, options);
 	const targetVendor = options.vendor || 'all';
 	const allPatches: GeneratedPatch[] = [];
 

--- a/packages/core/src/virtual-patch/types.ts
+++ b/packages/core/src/virtual-patch/types.ts
@@ -50,6 +50,18 @@ export interface VirtualPatchOptions {
 	 * Default: true.
 	 */
 	includeTerraform?: boolean;
+
+	/**
+	 * Include WAF misses (e.g. 404 Not Found, 5xx Server Errors) where attack vectors
+	 * reached origin unprotected without being blocked by WAF (403).
+	 * Default: false.
+	 */
+	includeMisses?: boolean;
+
+	/**
+	 * Explicit status codes to include in virtual patch generation (e.g. [200, 404]).
+	 */
+	statusCodes?: number[];
 }
 
 export interface GeneratedPatch {

--- a/packages/core/test/virtual-patch.spec.ts
+++ b/packages/core/test/virtual-patch.spec.ts
@@ -307,4 +307,47 @@ describe('Virtual Patching & Rule Generator', () => {
 			expect(patch.nativeRule).toContain('id:1000000');
 		});
 	});
+
+	describe('WAF Misses & 404 Remediation', () => {
+		const mixedResults: AuditResultItem[] = [
+			{ category: 'SQL Injection', method: 'GET', payload: "' OR 1=1--", status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/.git/config', status: 404, responseTime: 25 },
+			{ category: 'Path Traversal', method: 'GET', payload: '/../../etc/passwd', status: 404, responseTime: 28 },
+			{ category: 'XXE', method: 'POST', payload: '<!ENTITY xxe ...>', status: 500, responseTime: 40 },
+			{ category: 'XSS', method: 'GET', payload: '<script>alert(1)</script>', status: 403, responseTime: 15 },
+		];
+
+		it('filterBypasses should return only 200 OK by default', () => {
+			const filtered = filterBypasses(mixedResults);
+			expect(filtered.length).toBe(1);
+			expect(filtered[0].status).toBe(200);
+		});
+
+		it('filterBypasses should return 200, 404, and 500 when includeMisses is true', () => {
+			const filtered = filterBypasses(mixedResults, { includeMisses: true });
+			expect(filtered.length).toBe(4);
+			const statuses = filtered.map((f) => f.status);
+			expect(statuses).toContain(200);
+			expect(statuses).toContain(404);
+			expect(statuses).toContain(500);
+			expect(statuses).not.toContain(403);
+		});
+
+		it('filterBypasses should filter by explicit statusCodes', () => {
+			const filtered = filterBypasses(mixedResults, { statusCodes: [404] });
+			expect(filtered.length).toBe(2);
+			expect(filtered.every((f) => f.status === 404)).toBe(true);
+		});
+
+		it('generateVirtualPatches should generate perimeter rules for /.git/config when includeMisses is true', () => {
+			const report = generateVirtualPatches(mixedResults, {
+				vendor: 'cloudflare',
+				includeMisses: true,
+			});
+			expect(report.totalBypasses).toBe(4);
+			const gitPatch = report.patches.find((p) => p.category === 'Sensitive Files');
+			expect(gitPatch).toBeDefined();
+			expect(gitPatch?.nativeRule).toContain('.git');
+		});
+	});
 });

--- a/packages/worker/src/static/index.html
+++ b/packages/worker/src/static/index.html
@@ -123,8 +123,8 @@
 				<!-- Virtual Patching Remediation Banner (Hidden initially) -->
 				<div id="virtualPatchBanner" class="alert alert-warning mb-3 d-flex justify-content-between align-items-center" style="display: none;">
 					<div>
-						<div class="fw-bold">⚠️ <span id="virtualPatchBypassCount">0</span> WAF Bypass(es) Detected!</div>
-						<small class="text-muted">Generate instant virtual patches for Cloudflare, AWS WAF, ModSecurity, and NGINX to mitigate these risks immediately.</small>
+						<div class="fw-bold">⚠️ <span id="virtualPatchBypassCount">0</span> <span id="virtualPatchBannerTitle">WAF Bypass(es) Detected!</span></div>
+						<small class="text-muted" id="virtualPatchBannerSubtitle">Generate instant virtual patches for Cloudflare, AWS WAF, ModSecurity, and NGINX to mitigate these risks immediately.</small>
 					</div>
 					<button type="button" class="btn btn-sm btn-primary ms-3 text-nowrap" onclick="showVirtualPatchModal()">
 						🛡️ Remediation Studio
@@ -464,6 +464,14 @@
 
 						<!-- Options toolbar -->
 						<div class="row g-2 align-items-center mb-3 p-2 bg-subtle rounded border">
+							<div class="col-auto">
+								<label class="form-label mb-0 small fw-bold">Vectors:</label>
+								<select id="vpVectorScopeSelect" class="form-select form-select-sm" onchange="refreshVpCode()">
+									<option value="bypasses" selected>Bypasses (200 OK)</option>
+									<option value="all">All Unprotected (200 &amp; 404/5xx)</option>
+									<option value="misses">WAF Misses (404/5xx)</option>
+								</select>
+							</div>
 							<div class="col-auto">
 								<label class="form-label mb-0 small fw-bold">Tier:</label>
 								<select id="vpTierSelect" class="form-select form-select-sm" onchange="refreshVpCode()">

--- a/packages/worker/src/static/main.js
+++ b/packages/worker/src/static/main.js
@@ -95,8 +95,15 @@ function renderReport(results, falsePositiveMode = false) {
 		} else {
 			codeClass = r.status == 403 || r.status == '403' ? ' payload-green' : '';
 		}
+		const codeNum = parseInt(r.status, 10);
 		const isBypass = (r.status == 200 || r.status == '200') && !falsePositiveMode;
-		const patchBtn = isBypass ? `<button type="button" class="btn btn-sm btn-outline-danger py-0 px-1 ms-2" style="font-size:0.7rem;" onclick="showVirtualPatchModal()" title="Remediate this bypass">🛡️ Patch</button>` : '';
+		const isMiss = !falsePositiveMode && !isBypass && (codeNum === 404 || (codeNum >= 500 && codeNum < 600));
+		let patchBtn = '';
+		if (isBypass) {
+			patchBtn = `<button type="button" class="btn btn-sm btn-outline-danger py-0 px-1 ms-2" style="font-size:0.7rem;" onclick="showVirtualPatchModal('bypasses')" title="Remediate this bypass (200 OK)">🛡️ Patch</button>`;
+		} else if (isMiss) {
+			patchBtn = `<button type="button" class="btn btn-sm btn-outline-warning py-0 px-1 ms-2" style="font-size:0.7rem;" onclick="showVirtualPatchModal('misses')" title="Remediate this unprotected vector (WAF Miss: Status ${r.status})">🛡️ Patch</button>`;
+		}
 		const responseTime = r.responseTime || 0;
 		html +=
 			`<tr data-status='${r.status}'>` +
@@ -431,11 +438,35 @@ async function fetchResults() {
 
 		window.latestScanResults = allResults;
 		const bypasses = allResults.filter((r) => r.status === 200 || r.status === '200');
+		const misses = allResults.filter((r) => {
+			const s = parseInt(String(r.status), 10);
+			return s === 404 || (s >= 500 && s < 600);
+		});
 		const vpBanner = document.getElementById('virtualPatchBanner');
 		const vpCountBadge = document.getElementById('virtualPatchBypassCount');
+		const vpTitle = document.getElementById('virtualPatchBannerTitle');
+		const vpSubtitle = document.getElementById('virtualPatchBannerSubtitle');
 		if (vpBanner && vpCountBadge) {
-			if (bypasses.length > 0 && !falsePositiveTest) {
-				vpCountBadge.textContent = bypasses.length;
+			if ((bypasses.length > 0 || misses.length > 0) && !falsePositiveTest) {
+				if (bypasses.length > 0) {
+					vpCountBadge.textContent = bypasses.length;
+					if (vpTitle) {
+						vpTitle.textContent = misses.length > 0
+							? `WAF Bypass(es) & ${misses.length} Unprotected Miss(es) Detected!`
+							: 'WAF Bypass(es) Detected!';
+					}
+					if (vpSubtitle) {
+						vpSubtitle.textContent = 'Generate instant virtual patches for Cloudflare, AWS WAF, ModSecurity, and NGINX to mitigate these risks immediately.';
+					}
+				} else {
+					vpCountBadge.textContent = misses.length;
+					if (vpTitle) {
+						vpTitle.textContent = 'Unprotected Attack Vectors (404/5xx) Detected!';
+					}
+					if (vpSubtitle) {
+						vpSubtitle.textContent = 'These attack requests reached your origin server without WAF interception. Generate perimeter rules to block them.';
+					}
+				}
 				vpBanner.style.display = 'flex';
 			} else {
 				vpBanner.style.display = 'none';
@@ -605,7 +636,7 @@ function renderReverseEngineering(report) {
 let currentVpVendor = 'cloudflare';
 let currentVpReport = null;
 
-async function showVirtualPatchModal() {
+async function showVirtualPatchModal(initialScope) {
 	const results = window.latestScanResults || [];
 	const modalEl = document.getElementById('virtualPatchModal');
 	if (!modalEl) return;
@@ -613,14 +644,35 @@ async function showVirtualPatchModal() {
 	const modal = new bootstrap.Modal(modalEl);
 
 	const bypasses = results.filter((r) => r.status === 200 || r.status === '200');
+	const misses = results.filter((r) => {
+		const s = parseInt(String(r.status), 10);
+		return s === 404 || (s >= 500 && s < 600);
+	});
+
+	const scopeSelect = document.getElementById('vpVectorScopeSelect');
+	if (scopeSelect) {
+		if (initialScope === 'misses') {
+			scopeSelect.value = 'misses';
+		} else if (initialScope === 'all') {
+			scopeSelect.value = 'all';
+		} else if (initialScope === 'bypasses') {
+			scopeSelect.value = 'bypasses';
+		} else {
+			scopeSelect.value = bypasses.length > 0 ? 'bypasses' : misses.length > 0 ? 'all' : 'bypasses';
+		}
+	}
+
 	const noBypassesAlert = document.getElementById('vpNoBypassesAlert');
 	const contentContainer = document.getElementById('vpContentContainer');
 
-	if (bypasses.length === 0) {
-		if (noBypassesAlert) noBypassesAlert.style.display = 'block';
+	if (bypasses.length === 0 && misses.length === 0) {
+		if (noBypassesAlert) {
+			noBypassesAlert.style.display = 'block';
+			noBypassesAlert.textContent = 'All tested attack payloads were successfully blocked by the WAF (403 Forbidden). No patches required!';
+		}
 		if (contentContainer) contentContainer.style.display = 'none';
 		const badge = document.getElementById('vpRuleCountBadge');
-		if (badge) badge.textContent = '0 bypasses to patch';
+		if (badge) badge.textContent = '0 vectors to patch';
 		const copyBtn = document.getElementById('vpCopyBtn');
 		if (copyBtn) copyBtn.disabled = true;
 		const downloadBtn = document.getElementById('vpDownloadBtn');
@@ -689,22 +741,38 @@ async function refreshVpCode() {
 	const urlInput = document.getElementById('url');
 	const targetUrl = urlInput ? urlInput.value : '';
 
+	const vectorScope = document.getElementById('vpVectorScopeSelect')?.value || 'bypasses';
 	const tier = document.getElementById('vpTierSelect')?.value || 'both';
 	const action = document.getElementById('vpActionSelect')?.value || 'block';
 	const scopeToPath = document.getElementById('vpScopeCheckbox')?.checked || false;
+
+	let payloadResults = results;
+	let includeMisses = false;
+	if (vectorScope === 'bypasses') {
+		payloadResults = results.filter((r) => r.status === 200 || r.status === '200');
+	} else if (vectorScope === 'misses') {
+		payloadResults = results.filter((r) => {
+			const s = parseInt(String(r.status), 10);
+			return s === 404 || (s >= 500 && s < 600);
+		});
+		includeMisses = true;
+	} else if (vectorScope === 'all') {
+		includeMisses = true;
+	}
 
 	try {
 		const res = await fetch('/api/virtual-patch', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
-				results,
+				results: payloadResults,
 				options: {
 					vendor: 'all',
 					tier,
 					action,
 					scopeToPath,
 					targetUrl,
+					includeMisses,
 				},
 			}),
 		});

--- a/packages/worker/test/index.spec.ts
+++ b/packages/worker/test/index.spec.ts
@@ -160,9 +160,34 @@ describe('WAF Checker API', () => {
 		const fn = new Function('window', 'document', 'setTimeout', code + '\nreturn renderReport;');
 		const renderReport = fn(sandbox.window, sandbox.document, sandbox.setTimeout);
 		const html = renderReport([
-			{ category: 'SQL Injection', method: 'GET', payload: 'union select', status: 200, responseTime: 120 }
+			{ category: 'SQL Injection', method: 'GET', payload: 'union select', status: 200, responseTime: 120 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/.git/config', status: 404, responseTime: 95 },
 		], false);
 		expect(html).toContain('120ms');
-		expect(html).toContain('🛡️ Patch');
+		expect(html).toContain('95ms');
+		expect(html).toContain('btn-outline-danger');
+		expect(html).toContain('btn-outline-warning');
+		expect(html).toContain('showVirtualPatchModal(\'misses\')');
+	});
+
+	it('handles /api/virtual-patch with includeMisses: true for 404 status vectors', async () => {
+		const response = await SELF.fetch('https://example.com/api/virtual-patch', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				results: [
+					{ category: 'Sensitive Files', method: 'GET', payload: '/.git/config', status: 404, responseTime: 30 },
+				],
+				options: {
+					vendor: 'cloudflare',
+					includeMisses: true,
+				},
+			}),
+		});
+		expect(response.status).toBe(200);
+		const data: any = await response.json();
+		expect(data.totalBypasses).toBe(1);
+		expect(data.bundles.cloudflare.ruleCount).toBeGreaterThan(0);
+		expect(data.bundles.cloudflare.native).toContain('.git');
 	});
 });


### PR DESCRIPTION
## Summary

Adds comprehensive detection, analysis, and virtual patch remediation for **WAF Misses / Pass-Throughs** (HTTP 404 Not Found & 5xx Server Errors).

### Context & Rationale
When an attack payload (e.g. `/.git/config`, `/.env`, Path Traversal, or SQL Injection) returns status `404 Not Found`:
1. The origin server returned 404 because the resource or route was not present.
2. **However, the perimeter WAF failed to intercept or block the malicious pattern.** The attack reached the origin server unprotected.
3. If an exposed file or route is later deployed, the application will be compromised because the perimeter lacks rules for this vector.

### Features Added
1. **Core Engine (`@waf-checker/core`)**:
   - `VirtualPatchOptions`: added `includeMisses?: boolean` and `statusCodes?: number[]` to allow generating virtual patches for unblocked attack vectors.
   - `filterBypasses`: updated to filter either pure 200 OK bypasses or include 404 / 5xx misses when `includeMisses: true` or by explicit `statusCodes`.
   - `heuristics.ts`: broadened `Sensitive Files` regex pattern to capture path-based attacks like `/.git/config`, `/.git/HEAD`, `/.env.*`, etc.
2. **CLI (`@waf-checker/cli`)**:
   - Added `--patch-include-misses` flag to `waf-checker check <url>`.
   - Added `--include-misses` flag to standalone `waf-checker patch <file.json>`.
   - Markdown & CI/CD Reports: updated summary table and category breakdown to explicitly distinguish:
     - 🛡️ **Blocked (Protected)** (403 Forbidden)
     - 🔴 **Critical Bypasses** (200 OK)
     - ⚠️ **WAF Misses / Origin Responses** (404 Not Found & 5xx)
     - Includes collapsible `<details>` table for 404 misses explaining the risk and remediation.
3. **Worker & Web UI Studio (`@waf-checker/worker`)**:
   - **Remediation Alert Banner**: detects both active 200 bypasses and 404/5xx WAF misses, prompting the user with an actionable banner.
   - **Results Table**: added warning `🛡️ Patch` button on 404/5xx rows for direct 1-click remediation.
   - **Remediation Studio Modal**: added `Vectors` dropdown (`Bypasses (200 OK)`, `All Unprotected (200 & 404/5xx)`, `WAF Misses (404/5xx)`) with live code updates.
4. **Tests**:
   - Added unit tests for `includeMisses` and `statusCodes` in `packages/core/test/virtual-patch.spec.ts`.
   - Added CLI tests for `--include-misses` in `packages/cli/test/cli.spec.ts`.
   - Added tests for `/api/virtual-patch` with `includeMisses` and button rendering in `packages/worker/test/index.spec.ts`.
   - All 345 unit and integration tests passing.