### PR TITLE
fix(virtual-patch): join Cloudflare Wirefilter rules with boolean or and consolidate sensitive extensions

### DIFF
--- a/packages/core/src/virtual-patch/generators/aws.ts
+++ b/packages/core/src/virtual-patch/generators/aws.ts
@@ -67,7 +67,7 @@ export function generateAwsPatches(
 
 		// 1. Strict Hotfix Tier
 		if (options.tier !== 'heuristic') {
-			const tokens = [...new Set(items.map((it) => sanitizeStrictToken(it.payload)))];
+			const tokens = [...new Set(items.map((it) => sanitizeStrictToken(it.payload, category)))];
 			const byteStatements = tokens.map((tok) => ({
 				ByteMatchStatement: {
 					SearchString: tok,

--- a/packages/core/src/virtual-patch/generators/cloudflare.ts
+++ b/packages/core/src/virtual-patch/generators/cloudflare.ts
@@ -68,7 +68,7 @@ export function generateCloudflarePatches(
 
 		// 1. Strict Hotfix Tier
 		if (options.tier !== 'heuristic') {
-			const tokens = Array.from(new Set(items.map((i) => sanitizeStrictToken(i.payload)))).filter(Boolean);
+			const tokens = Array.from(new Set(items.map((i) => sanitizeStrictToken(i.payload, category)))).filter(Boolean);
 			const matchClauses = tokens.map(
 				(t) => `(lower(${cfField}) contains "${t.replace(/\\/g, '\\\\').replace(/"/g, '\\"').toLowerCase()}")`
 			);

--- a/packages/core/src/virtual-patch/generators/modsecurity.ts
+++ b/packages/core/src/virtual-patch/generators/modsecurity.ts
@@ -58,7 +58,7 @@ export function generateModSecurityPatches(
 
 		// 1. Strict Hotfix Tier
 		if (options.tier !== 'heuristic') {
-			const tokens = [...new Set(items.map((it) => sanitizeStrictToken(it.payload)))];
+			const tokens = [...new Set(items.map((it) => sanitizeStrictToken(it.payload, category)))];
 			const lines: string[] = [
 				`# ------------------------------------------------------------------------`,
 				`# WAF-Checker Virtual Patch: ${category} (Strict)`,

--- a/packages/core/src/virtual-patch/generators/nginx.ts
+++ b/packages/core/src/virtual-patch/generators/nginx.ts
@@ -60,7 +60,7 @@ export function generateNginxPatches(
 
 		// 1. Strict Hotfix Tier
 		if (options.tier !== 'heuristic') {
-			const tokens = [...new Set(items.map((it) => sanitizeStrictToken(it.payload)))];
+			const tokens = [...new Set(items.map((it) => sanitizeStrictToken(it.payload, category)))];
 			const escapedAlternation = tokens.map((tok) => escapeNginxString(escapeRegex(tok))).join('|');
 
 			const lines: string[] = [

--- a/packages/core/src/virtual-patch/heuristics.ts
+++ b/packages/core/src/virtual-patch/heuristics.ts
@@ -162,14 +162,112 @@ export function escapeNginxString(str: string): string {
 }
 
 /**
- * Cleans and extracts a meaningful literal token from an attack payload for strict matching.
- * Trims extraneous whitespace while preserving essential attack signature tokens.
+ * Common sensitive file extensions and paths that should never be exposed or publicly served on web servers.
+ * When generating virtual patches, specific filenames (e.g. 'dump.sql', 'db.sql', 'database.sql') are
+ * consolidated into generic extension rules (e.g. '.sql') for broader perimeter defense and compact rules.
  */
-export function sanitizeStrictToken(payload: string): string {
-	return payload
-		.replace(/[\r\n]+/g, ' ')
-		.trim()
-		.slice(0, 200); // Reasonable bound for token matchers
+export const SENSITIVE_EXTENSIONS: readonly string[] = [
+	// Compound archive extensions (must precede single extensions)
+	'.tar.gz',
+	'.tar.bz2',
+	'.tar.xz',
+	// Databases & dumps
+	'.sql',
+	'.db',
+	'.sqlite',
+	'.sqlite3',
+	'.dump',
+	'.rdb',
+	'.mdb',
+	'.accdb',
+	// Backups & archives
+	'.bak',
+	'.old',
+	'.orig',
+	'.backup',
+	'.swp',
+	'.~',
+	'.sav',
+	'.save',
+	'.copy',
+	'.tar',
+	'.tgz',
+	'.gz',
+	'.bz2',
+	'.xz',
+	'.zip',
+	'.rar',
+	'.7z',
+	// Configs, secrets & environment
+	'.env',
+	'.ini',
+	'.conf',
+	'.cfg',
+	'.config',
+	'.yml',
+	'.yaml',
+	'.toml',
+	// Keys, certificates & keystores
+	'.key',
+	'.pem',
+	'.crt',
+	'.cer',
+	'.der',
+	'.p12',
+	'.pfx',
+	'.jks',
+	'.keystore',
+	'.pub',
+	// Logs
+	'.log',
+	// Scripts & executables
+	'.sh',
+	'.bash',
+	'.bat',
+	'.cmd',
+	'.ps1',
+	'.vbs',
+	// Source control & metadata
+	'.git',
+	'.svn',
+	'.hg',
+	'.ds_store',
+	'.htpasswd',
+	'.htaccess',
+];
+
+/**
+ * Cleans and extracts a meaningful literal token from an attack payload for strict matching.
+ * For sensitive file checks, consolidates specific filenames (e.g. "dump.sql", "db.sql") into
+ * their dangerous file extension (e.g. ".sql") or hidden directory prefix (e.g. ".git").
+ */
+export function sanitizeStrictToken(payload: string, category?: string): string {
+	const trimmed = payload.replace(/[\r\n]+/g, ' ').trim();
+	const normalized = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed;
+
+	if (category === 'Sensitive Files' || category === 'Path Traversal') {
+		const lower = normalized.toLowerCase();
+
+		// Check hidden VCS / env directory paths first (e.g. .git/config -> .git)
+		if (lower.startsWith('.git') || lower.includes('/.git')) return '.git';
+		if (lower.startsWith('.env') || lower.includes('/.env')) return '.env';
+		if (lower.startsWith('.svn') || lower.includes('/.svn')) return '.svn';
+		if (lower.startsWith('.hg') || lower.includes('/.hg')) return '.hg';
+
+		// Check known sensitive extensions (.tar.gz before .gz, .sqlite3 before .sql, etc.)
+		for (const ext of SENSITIVE_EXTENSIONS) {
+			if (
+				lower.endsWith(ext) ||
+				lower.includes(`${ext}?`) ||
+				lower.includes(`${ext}#`) ||
+				lower.includes(`${ext}/`)
+			) {
+				return ext;
+			}
+		}
+	}
+
+	return trimmed.slice(0, 200);
 }
 
 /**

--- a/packages/core/src/virtual-patch/index.ts
+++ b/packages/core/src/virtual-patch/index.ts
@@ -80,9 +80,21 @@ export function generateVirtualPatches(
 			.filter((p) => p.terraformHcl)
 			.map((p) => p.terraformHcl!);
 
+		let nativeJoined = '';
+		if (v === 'cloudflare') {
+			// In Cloudflare Wirefilter, all expressions in the custom firewall rule must be
+			// joined with boolean 'or' so it forms a single, syntactically valid expression.
+			nativeJoined =
+				nativeParts.length <= 1
+					? nativeParts[0] || ''
+					: nativeParts.join(' or\n\n');
+		} else {
+			nativeJoined = nativeParts.join('\n\n');
+		}
+
 		bundles[v] = {
 			vendor: v,
-			native: nativeParts.join('\n\n'),
+			native: nativeJoined,
 			terraform: tfParts.length > 0 ? tfParts.join('\n\n') : undefined,
 			ruleCount: vendorPatches.length,
 		};

--- a/packages/core/test/virtual-patch.spec.ts
+++ b/packages/core/test/virtual-patch.spec.ts
@@ -77,8 +77,18 @@ describe('Virtual Patching & Rule Generator', () => {
 			expect(escapeRegex('127.0.0.1')).toBe('127\\.0\\.0\\.1');
 		});
 
-		it('should sanitize strict tokens properly', () => {
+		it('should sanitize strict tokens properly and consolidate sensitive extensions', () => {
 			expect(sanitizeStrictToken("  ' OR '1'='1 \n")).toBe("' OR '1'='1");
+			expect(sanitizeStrictToken('/dump.sql', 'Sensitive Files')).toBe('.sql');
+			expect(sanitizeStrictToken('database.sql', 'Sensitive Files')).toBe('.sql');
+			expect(sanitizeStrictToken('db.sql', 'Sensitive Files')).toBe('.sql');
+			expect(sanitizeStrictToken('backup.tar.gz', 'Sensitive Files')).toBe('.tar.gz');
+			expect(sanitizeStrictToken('backup.zip', 'Sensitive Files')).toBe('.zip');
+			expect(sanitizeStrictToken('server.key', 'Sensitive Files')).toBe('.key');
+			expect(sanitizeStrictToken('server.pem', 'Sensitive Files')).toBe('.pem');
+			expect(sanitizeStrictToken('.git/config', 'Sensitive Files')).toBe('.git');
+			expect(sanitizeStrictToken('.env', 'Sensitive Files')).toBe('.env');
+			expect(sanitizeStrictToken('wp-config.php', 'Sensitive Files')).toBe('wp-config.php');
 		});
 
 		it('should detect inspection location correctly', () => {
@@ -348,6 +358,34 @@ describe('Virtual Patching & Rule Generator', () => {
 			const gitPatch = report.patches.find((p) => p.category === 'Sensitive Files');
 			expect(gitPatch).toBeDefined();
 			expect(gitPatch?.nativeRule).toContain('.git');
+		});
+	});
+
+	describe('Cloudflare Wirefilter & Extension Consolidation', () => {
+		it('should consolidate dump.sql and db.sql into a single .sql match in Cloudflare rules', () => {
+			const sqlFiles: AuditResultItem[] = [
+				{ category: 'Sensitive Files', method: 'GET', payload: '/dump.sql', status: 200, responseTime: 20 },
+				{ category: 'Sensitive Files', method: 'GET', payload: '/db.sql', status: 200, responseTime: 20 },
+				{ category: 'Sensitive Files', method: 'GET', payload: '/database.sql', status: 200, responseTime: 20 },
+			];
+
+			const report = generateVirtualPatches(sqlFiles, { vendor: 'cloudflare', tier: 'strict' });
+			const cfBundle = report.bundles.cloudflare;
+			expect(cfBundle.native).toContain('contains ".sql"');
+			expect(cfBundle.native).not.toContain('contains "dump.sql"');
+			expect(cfBundle.native).not.toContain('contains "db.sql"');
+		});
+
+		it('should join multiple Cloudflare rules with boolean "or" in native bundle for valid Wirefilter syntax', () => {
+			const mixed: AuditResultItem[] = [
+				{ category: 'Sensitive Files', method: 'GET', payload: '/dump.sql', status: 200, responseTime: 20 },
+			];
+
+			const report = generateVirtualPatches(mixed, { vendor: 'cloudflare', tier: 'both' });
+			const cfBundle = report.bundles.cloudflare;
+			expect(cfBundle.ruleCount).toBe(2);
+			expect(cfBundle.native).toContain(' or\n\n');
+			expect(cfBundle.native).toMatch(/\)\s+or\s+\(/);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes two issues reported with Cloudflare WAF virtual patch generation and sensitive files remediation:

### 1. Cloudflare Wirefilter Rule Joining (` or `)
- **Problem**: In Cloudflare's Expression Builder / Custom Rules, only a single boolean expression is accepted. When `Dual-Tier` (strict + heuristic) or multiple attack categories were generated, rules were previously separated by empty newlines (`\n\n`), resulting in the second expression appearing detached and breaking Cloudflare's Wirefilter syntax parser (`Filter parsing error: unexpected token "("`).
- **Solution**: In `packages/core/src/virtual-patch/index.ts`, Cloudflare native rules in the bundle are now connected with boolean ` or\n\n`. When copied or viewed, the entire output forms a single, 100% syntactically valid Cloudflare Wirefilter expression that can be pasted directly into Cloudflare WAF Custom Rules.

### 2. Sensitive File Extensions Consolidation
- **Problem**: Previously, strict hotfixes for Sensitive Files listed individual filenames separately: `(lower(http.request.uri.path) contains "dump.sql") or (lower(http.request.uri.path) contains "database.sql") or (lower(http.request.uri.path) contains "db.sql")` alongside `backup.gz`, `backup.zip`, etc. This was verbose, hit rule character limits, and missed other variants (e.g. `users.sql`).
- **Solution**:
  - Added `SENSITIVE_EXTENSIONS` in `packages/core/src/virtual-patch/heuristics.ts` covering dangerous extensions and paths that web servers should never serve publicly:
    - Databases & dumps: `.sql`, `.db`, `.sqlite`, `.sqlite3`, `.dump`, `.rdb`, `.mdb`, `.accdb`
    - Backups & archives: `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.bak`, `.old`, `.orig`, `.backup`, `.swp`, `.~`, `.sav`, `.tar`, `.tgz`, `.gz`, `.bz2`, `.xz`, `.zip`, `.rar`, `.7z`
    - Configs & secrets: `.env`, `.ini`, `.conf`, `.cfg`, `.config`, `.yml`, `.yaml`, `.toml`
    - Keys & certs: `.key`, `.pem`, `.crt`, `.cer`, `.der`, `.p12`, `.pfx`, `.jks`, `.keystore`, `.pub`
    - Logs: `.log`
    - Scripts: `.sh`, `.bash`, `.bat`, `.cmd`, `.ps1`, `.vbs`
    - Version control: `.git`, `.svn`, `.hg`, `.ds_store`, `.htpasswd`, `.htaccess`
  - Updated `sanitizeStrictToken(payload, category)` across all generators (`cloudflare.ts`, `aws.ts`, `modsecurity.ts`, `nginx.ts`) to automatically reduce specific filenames down to their dangerous extension (e.g. `dump.sql` -> `.sql`) and deduplicate them. Legitimate web file types (e.g. `wp-config.php`, `composer.json`) continue to preserve their specific filename token.

### 3. Tests
- Added unit tests in `packages/core/test/virtual-patch.spec.ts` verifying extension consolidation and Cloudflare ` or ` joining.
- All tests passing.