### PR TITLE
feat(virtual-patch): add Google Cloud Armor rule generator (CEL, gcloud CLI, Terraform)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -180,7 +180,7 @@ checkCmd
 	.option('--threshold <percent>', 'Minimum protection score percentage required to pass (e.g. 95). Exits with code 1 if score is lower')
 	.option('--reverse', 'Run deep WAF Reverse Engineering and OWASP Core Rule Set (CRS) audit', false)
 	.option('--reverse-engineer', 'Alias for --reverse', false)
-	.option('--patch [vendor]', 'Generate ready-to-deploy virtual patches (cloudflare, aws, modsecurity, nginx, all)')
+	.option('--patch [vendor]', 'Generate ready-to-deploy virtual patches (cloudflare, aws, modsecurity, nginx, gcp, all)')
 	.option('--patch-output <path>', 'File path or directory to save generated virtual patch(es) to')
 	.option('--patch-tier <tier>', 'Defense tier: strict (exact token), heuristic (regex pattern), or both', 'both')
 	.option('--patch-action <action>', 'Rule action: block or simulate', 'block')
@@ -600,7 +600,7 @@ batchCmd
 program
 	.command('patch <file>')
 	.description('Generate ready-to-deploy virtual patches from a saved JSON audit report')
-	.option('-w, --waf <vendor>', 'Target WAF vendor (cloudflare, aws, modsecurity, nginx, all)', 'all')
+	.option('-w, --waf <vendor>', 'Target WAF vendor (cloudflare, aws, modsecurity, nginx, gcp, all)', 'all')
 	.option('-t, --tier <tier>', 'Defense tier: strict, heuristic, or both', 'both')
 	.option('-a, --action <action>', 'Rule action: block or simulate', 'block')
 	.option('-o, --output <path>', 'Output file or directory to write patches to')
@@ -676,6 +676,10 @@ program
 					if (b.ruleCount === 0) continue;
 					console.log(`\n--- ${v.toUpperCase()} ---`);
 					console.log(b.native);
+					if (b.gcloud) {
+						console.log(`\n--- ${v.toUpperCase()} (gcloud CLI) ---`);
+						console.log(b.gcloud);
+					}
 					if (b.terraform) {
 						console.log(`\n--- ${v.toUpperCase()} (Terraform) ---`);
 						console.log(b.terraform);

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -809,5 +809,33 @@ describe('CLI Argument Processing', () => {
 
 			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('CLOUDFLARE'));
 		});
+
+		it('should generate GCP Cloud Armor patches when --waf gcp is specified', async () => {
+			vi.mocked(fs.existsSync).mockReturnValueOnce(true);
+			vi.mocked(fs.readFileSync).mockReturnValueOnce(
+				JSON.stringify([
+					{
+						category: 'Sensitive Files',
+						method: 'GET',
+						payload: '/dump.sql',
+						status: 200,
+						responseTime: 40,
+					},
+				])
+			);
+
+			await expect(
+				program.parseAsync([
+					'node',
+					'index.js',
+					'patch',
+					'report.json',
+					'--waf',
+					'gcp',
+				])
+			).resolves.toBeDefined();
+
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('GCP'));
+		});
 	});
 });

--- a/packages/core/src/virtual-patch/generators/gcp.ts
+++ b/packages/core/src/virtual-patch/generators/gcp.ts
@@ -1,0 +1,189 @@
+import { AuditResultItem } from '../../reports/types';
+import { VirtualPatchOptions, GeneratedPatch } from '../types';
+import {
+	CATEGORY_HEURISTICS,
+	detectInspectionLocation,
+	escapeRegex,
+	sanitizeStrictToken,
+	escapeHclString,
+} from '../heuristics';
+
+function getUrlPath(targetUrl?: string): string | null {
+	if (!targetUrl) return null;
+	try {
+		const parsed = new URL(targetUrl);
+		return parsed.pathname !== '/' ? parsed.pathname : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Escapes characters for embedding inside CEL single-quoted string literals.
+ */
+function escapeCelString(str: string): string {
+	return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+/**
+ * Maps logical location to Google Cloud Armor CEL (Common Expression Language) request field.
+ */
+function getCelField(location: 'query' | 'body' | 'header' | 'uri', category: string): string {
+	switch (location) {
+		case 'header':
+			if (category === 'User-Agent') return "request.headers['user-agent']";
+			if (category.includes('JWT')) return "request.headers['authorization']";
+			return "request.headers['x-forwarded-for']";
+		case 'uri':
+			return 'request.path';
+		case 'body':
+		case 'query':
+		default:
+			return 'request.query';
+	}
+}
+
+/**
+ * Generates Google Cloud Armor security policy rules (CEL expressions, gcloud CLI commands, and Terraform HCL).
+ */
+export function generateGcpPatches(
+	bypasses: AuditResultItem[],
+	options: VirtualPatchOptions = {}
+): GeneratedPatch[] {
+	const patches: GeneratedPatch[] = [];
+	const isSimulate = options.action === 'simulate';
+	const urlPath = options.scopeToPath ? getUrlPath(options.targetUrl) : null;
+	const pathScope = urlPath ? `request.path == '${escapeCelString(urlPath)}' && ` : '';
+	let currentPriority = options.ruleIdPrefix ? Math.floor(options.ruleIdPrefix / 1000) : 1000;
+
+	const groups: Record<string, AuditResultItem[]> = {};
+	if (options.groupByCategory !== false) {
+		for (const b of bypasses) {
+			const cat = b.category || 'General Attack';
+			if (!groups[cat]) groups[cat] = [];
+			groups[cat].push(b);
+		}
+	} else {
+		bypasses.forEach((b, idx) => {
+			groups[`${b.category || 'Attack'}_${idx}`] = [b];
+		});
+	}
+
+	for (const [category, items] of Object.entries(groups)) {
+		const sampleItem = items[0];
+		const location = detectInspectionLocation(category, sampleItem.method, sampleItem.payload);
+		const celField = getCelField(location, category);
+		const sanitizedCat = category.replace(/[^a-zA-Z0-9]/g, '_');
+		const gcloudPreviewFlag = isSimulate ? ' --preview' : '';
+
+		// 1. Strict Hotfix Tier
+		if (options.tier !== 'heuristic') {
+			const tokens = Array.from(new Set(items.map((i) => sanitizeStrictToken(i.payload, category)))).filter(
+				Boolean
+			);
+
+			const matchClauses: string[] = [];
+			if (location === 'uri') {
+				for (const tok of tokens) {
+					if (tok === '.git' || tok === '.svn' || tok === '.hg') {
+						matchClauses.push(`request.path.matches('/\\\\.(?:${tok.slice(1)})')`);
+					} else if (tok.startsWith('.')) {
+						matchClauses.push(`request.path.lower().endsWith('${escapeCelString(tok.toLowerCase())}')`);
+					} else {
+						const cleanTok = tok.startsWith('/') ? tok : `/${tok}`;
+						matchClauses.push(`request.path.lower().endsWith('${escapeCelString(cleanTok.toLowerCase())}')`);
+					}
+				}
+			} else {
+				for (const tok of tokens) {
+					const escaped = escapeCelString(tok.toLowerCase());
+					matchClauses.push(`${celField}.lower().contains('${escaped}')`);
+				}
+			}
+
+			const condition = matchClauses.length === 1 ? matchClauses[0] : `(${matchClauses.join(' || ')})`;
+			const fullExpression = `${pathScope}${condition}`;
+
+			const terraformSnippet = `resource "google_compute_security_policy" "virtual_patch_${sanitizedCat}_strict" {
+  name        = "waf-checker-security-policy"
+  description = "Auto-generated Cloud Armor virtual patch for ${category} (Strict)"
+
+  rule {
+    action      = "deny(403)"
+    priority    = "${currentPriority}"
+    description = "Block verified ${category} bypass tokens"
+    preview     = ${isSimulate}
+
+    match {
+      expr {
+        expression = "${escapeHclString(fullExpression)}"
+      }
+    }
+  }
+}`;
+
+			const gcloudCmd = `gcloud compute security-policies rules create ${currentPriority} \\
+    --security-policy="waf-checker-policy" \\
+    --expression="${fullExpression.replace(/"/g, '\\"')}" \\
+    --action="deny-403" \\
+    --description="Block verified ${category} bypass tokens"${gcloudPreviewFlag}`;
+
+			patches.push({
+				vendor: 'gcp',
+				name: `Google Cloud Armor: ${category} (Strict Hotfix)`,
+				category,
+				tier: 'strict',
+				nativeRule: fullExpression,
+				terraformHcl: terraformSnippet,
+				gcloudCommand: gcloudCmd,
+				description: `Cloud Armor CEL rule matching ${tokens.length} verified ${category} bypass token(s)`,
+			});
+			currentPriority += 10;
+		}
+
+		// 2. Heuristic Pattern Tier
+		if (options.tier !== 'strict') {
+			const heuristic = CATEGORY_HEURISTICS[category];
+			const rawPattern = heuristic ? heuristic.pattern : escapeRegex(items[0].payload);
+			const fullExpression = `${pathScope}(${celField}.matches('${escapeCelString(rawPattern)}'))`;
+
+			const terraformSnippet = `resource "google_compute_security_policy" "virtual_patch_${sanitizedCat}_heuristic" {
+  name        = "waf-checker-security-policy"
+  description = "Auto-generated Cloud Armor heuristic defense for ${category}"
+
+  rule {
+    action      = "deny(403)"
+    priority    = "${currentPriority}"
+    description = "Heuristic regex defense for ${category}"
+    preview     = ${isSimulate}
+
+    match {
+      expr {
+        expression = "${escapeHclString(fullExpression)}"
+      }
+    }
+  }
+}`;
+
+			const gcloudCmd = `gcloud compute security-policies rules create ${currentPriority} \\
+    --security-policy="waf-checker-policy" \\
+    --expression="${fullExpression.replace(/"/g, '\\"')}" \\
+    --action="deny-403" \\
+    --description="Heuristic regex defense for ${category}"${gcloudPreviewFlag}`;
+
+			patches.push({
+				vendor: 'gcp',
+				name: `Google Cloud Armor: ${category} (Heuristic Pattern)`,
+				category,
+				tier: 'heuristic',
+				nativeRule: fullExpression,
+				terraformHcl: terraformSnippet,
+				gcloudCommand: gcloudCmd,
+				description: heuristic ? heuristic.description : `Cloud Armor heuristic regex defense for ${category}`,
+			});
+			currentPriority += 10;
+		}
+	}
+
+	return patches;
+}

--- a/packages/core/src/virtual-patch/index.ts
+++ b/packages/core/src/virtual-patch/index.ts
@@ -10,6 +10,7 @@ import { generateCloudflarePatches } from './generators/cloudflare';
 import { generateAwsPatches } from './generators/aws';
 import { generateModSecurityPatches } from './generators/modsecurity';
 import { generateNginxPatches } from './generators/nginx';
+import { generateGcpPatches } from './generators/gcp';
 
 export * from './types';
 export * from './heuristics';
@@ -17,6 +18,7 @@ export * from './generators/cloudflare';
 export * from './generators/aws';
 export * from './generators/modsecurity';
 export * from './generators/nginx';
+export * from './generators/gcp';
 
 /**
  * Filters audit results to isolate confirmed WAF bypasses (HTTP 200)
@@ -64,13 +66,16 @@ export function generateVirtualPatches(
 		if (targetVendor === 'all' || targetVendor === 'nginx') {
 			allPatches.push(...generateNginxPatches(bypasses, options));
 		}
+		if (targetVendor === 'all' || targetVendor === 'gcp') {
+			allPatches.push(...generateGcpPatches(bypasses, options));
+		}
 	}
 
 	// Build vendor-level bundle strings for easy 1-click copy / download
 	const bundles: Record<string, VendorPatchBundle> = {};
 	const vendorsToBundle: PatchVendor[] =
 		targetVendor === 'all'
-			? ['cloudflare', 'aws', 'modsecurity', 'nginx']
+			? ['cloudflare', 'aws', 'modsecurity', 'nginx', 'gcp']
 			: [targetVendor];
 
 	for (const v of vendorsToBundle) {
@@ -79,6 +84,9 @@ export function generateVirtualPatches(
 		const tfParts = vendorPatches
 			.filter((p) => p.terraformHcl)
 			.map((p) => p.terraformHcl!);
+		const gcloudParts = vendorPatches
+			.filter((p) => p.gcloudCommand)
+			.map((p) => p.gcloudCommand!);
 
 		let nativeJoined = '';
 		if (v === 'cloudflare') {
@@ -88,6 +96,12 @@ export function generateVirtualPatches(
 				nativeParts.length <= 1
 					? nativeParts[0] || ''
 					: nativeParts.join(' or\n\n');
+		} else if (v === 'gcp') {
+			// In Cloud Armor CEL, join expressions with boolean '||'
+			nativeJoined =
+				nativeParts.length <= 1
+					? nativeParts[0] || ''
+					: nativeParts.join(' ||\n\n');
 		} else if (v === 'aws') {
 			// Format multiple AWS WAF rules as a valid JSON array for AWS CLI / CloudFormation
 			if (nativeParts.length <= 1) {
@@ -108,6 +122,7 @@ export function generateVirtualPatches(
 			vendor: v,
 			native: nativeJoined,
 			terraform: tfParts.length > 0 ? tfParts.join('\n\n') : undefined,
+			gcloud: gcloudParts.length > 0 ? gcloudParts.join('\n\n') : undefined,
 			ruleCount: vendorPatches.length,
 		};
 	}

--- a/packages/core/src/virtual-patch/types.ts
+++ b/packages/core/src/virtual-patch/types.ts
@@ -1,6 +1,6 @@
 import { AuditResultItem } from '../reports/types';
 
-export type PatchVendor = 'cloudflare' | 'aws' | 'modsecurity' | 'nginx' | 'all';
+export type PatchVendor = 'cloudflare' | 'aws' | 'modsecurity' | 'nginx' | 'gcp' | 'all';
 export type PatchTier = 'strict' | 'heuristic' | 'both';
 export type PatchAction = 'block' | 'simulate';
 
@@ -46,7 +46,7 @@ export interface VirtualPatchOptions {
 	ruleIdPrefix?: number;
 
 	/**
-	 * Include Terraform HCL snippets where supported (Cloudflare & AWS WAF).
+	 * Include Terraform HCL snippets where supported (Cloudflare, AWS WAF & GCP Cloud Armor).
 	 * Default: true.
 	 */
 	includeTerraform?: boolean;
@@ -71,6 +71,7 @@ export interface GeneratedPatch {
 	tier: 'strict' | 'heuristic';
 	nativeRule: string;
 	terraformHcl?: string;
+	gcloudCommand?: string;
 	description: string;
 }
 
@@ -78,6 +79,7 @@ export interface VendorPatchBundle {
 	vendor: PatchVendor;
 	native: string;
 	terraform?: string;
+	gcloud?: string;
 	ruleCount: number;
 }
 

--- a/packages/core/test/virtual-patch.spec.ts
+++ b/packages/core/test/virtual-patch.spec.ts
@@ -123,11 +123,13 @@ describe('Virtual Patching & Rule Generator', () => {
 			expect(report.bundles.aws).toBeDefined();
 			expect(report.bundles.modsecurity).toBeDefined();
 			expect(report.bundles.nginx).toBeDefined();
+			expect(report.bundles.gcp).toBeDefined();
 
 			expect(report.bundles.cloudflare.ruleCount).toBeGreaterThan(0);
 			expect(report.bundles.aws.ruleCount).toBeGreaterThan(0);
 			expect(report.bundles.modsecurity.ruleCount).toBeGreaterThan(0);
 			expect(report.bundles.nginx.ruleCount).toBeGreaterThan(0);
+			expect(report.bundles.gcp.ruleCount).toBeGreaterThan(0);
 		});
 
 		it('should filter by specific vendor when requested', () => {
@@ -425,6 +427,55 @@ describe('Virtual Patching & Rule Generator', () => {
 			const parsed = JSON.parse(awsBundle.native);
 			expect(Array.isArray(parsed)).toBe(true);
 			expect(parsed[0].Name).toBeDefined();
+		});
+	});
+
+	describe('Google Cloud Armor Generator', () => {
+		const sensitiveFiles: AuditResultItem[] = [
+			{ category: 'Sensitive Files', method: 'GET', payload: '/dump.sql', status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/backup.zip', status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/.git/config', status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/wp-config.php', status: 200, responseTime: 20 },
+		];
+
+		it('should generate valid CEL expressions for sensitive files and attack vectors', () => {
+			const report = generateVirtualPatches(sensitiveFiles, { vendor: 'gcp', tier: 'strict' });
+			const patch = report.patches[0];
+			expect(patch.vendor).toBe('gcp');
+			expect(patch.nativeRule).toContain("request.path.lower().endsWith('.sql')");
+			expect(patch.nativeRule).toContain("request.path.lower().endsWith('.zip')");
+			expect(patch.nativeRule).toContain("request.path.matches('/\\\\.(?:git)')");
+			expect(patch.nativeRule).toContain("request.path.lower().endsWith('/wp-config.php')");
+			expect(patch.terraformHcl).toContain('google_compute_security_policy');
+			expect(patch.terraformHcl).toContain('action      = "deny(403)"');
+			expect(patch.gcloudCommand).toContain('gcloud compute security-policies rules create');
+		});
+
+		it('should support simulation mode (preview = true) in Cloud Armor', () => {
+			const report = generateVirtualPatches(mockBypasses, { vendor: 'gcp', action: 'simulate' });
+			const patch = report.patches[0];
+			expect(patch.terraformHcl).toContain('preview     = true');
+			expect(patch.gcloudCommand).toContain('--preview');
+		});
+
+		it('should scope Cloud Armor rules to URL path when requested', () => {
+			const report = generateVirtualPatches(mockBypasses, {
+				vendor: 'gcp',
+				scopeToPath: true,
+				targetUrl: 'https://example.com/api/v1',
+			});
+			const patch = report.patches[0];
+			expect(patch.nativeRule).toContain("request.path == '/api/v1' &&");
+		});
+
+		it('should join multiple CEL rules with || in bundle', () => {
+			const report = generateVirtualPatches(mockBypasses, { vendor: 'gcp', tier: 'both' });
+			const gcpBundle = report.bundles.gcp;
+			expect(gcpBundle).toBeDefined();
+			expect(gcpBundle.ruleCount).toBeGreaterThan(1);
+			expect(gcpBundle.native).toContain(' ||\n\n');
+			expect(gcpBundle.terraform).toContain('google_compute_security_policy');
+			expect(gcpBundle.gcloud).toContain('gcloud compute security-policies');
 		});
 	});
 });

--- a/packages/worker/src/static/index.html
+++ b/packages/worker/src/static/index.html
@@ -460,6 +460,9 @@
 							<li class="nav-item" role="presentation">
 								<button class="nav-link" id="tab-nginx" onclick="selectVpVendor('nginx')">🟩 NGINX</button>
 							</li>
+							<li class="nav-item" role="presentation">
+								<button class="nav-link" id="tab-gcp" onclick="selectVpVendor('gcp')">☁️ Cloud Armor</button>
+							</li>
 						</ul>
 
 						<!-- Options toolbar -->
@@ -492,6 +495,7 @@
 								<select id="vpFormatSelect" class="form-select form-select-sm" onchange="refreshVpCode()">
 									<option value="native" selected>Native Rules</option>
 									<option value="terraform">Terraform (HCL)</option>
+									<option value="gcloud">gcloud CLI Command</option>
 								</select>
 							</div>
 							<div class="col-auto ms-auto">

--- a/packages/worker/src/static/main.js
+++ b/packages/worker/src/static/main.js
@@ -694,6 +694,8 @@ async function showVirtualPatchModal(initialScope) {
 		currentVpVendor = 'cloudflare';
 	} else if (detectedWAF.includes('aws') || detectedWAF.includes('amazon')) {
 		currentVpVendor = 'aws';
+	} else if (detectedWAF.includes('cloud armor') || detectedWAF.includes('gcp') || detectedWAF.includes('google')) {
+		currentVpVendor = 'gcp';
 	} else if (detectedWAF.includes('modsecurity') || detectedWAF.includes('coraza')) {
 		currentVpVendor = 'modsecurity';
 	} else if (detectedWAF.includes('nginx')) {
@@ -706,7 +708,7 @@ async function showVirtualPatchModal(initialScope) {
 }
 
 function updateVpTabs() {
-	const vendors = ['cloudflare', 'aws', 'modsecurity', 'nginx'];
+	const vendors = ['cloudflare', 'aws', 'modsecurity', 'nginx', 'gcp'];
 	vendors.forEach((v) => {
 		const btn = document.getElementById(`tab-${v}`);
 		if (btn) {
@@ -718,13 +720,23 @@ function updateVpTabs() {
 		}
 	});
 
-	// Toggle Terraform option visibility (only Cloudflare & AWS support it)
+	// Toggle Terraform and gcloud option visibility
 	const formatContainer = document.getElementById('vpFormatContainer');
 	const formatSelect = document.getElementById('vpFormatSelect');
-	if (formatContainer) {
-		const supportsTf = currentVpVendor === 'cloudflare' || currentVpVendor === 'aws';
-		formatContainer.style.display = supportsTf ? 'block' : 'none';
-		if (!supportsTf && formatSelect) {
+	if (formatContainer && formatSelect) {
+		const supportsTf = currentVpVendor === 'cloudflare' || currentVpVendor === 'aws' || currentVpVendor === 'gcp';
+		const supportsGcloud = currentVpVendor === 'gcp';
+
+		const tfOpt = formatSelect.querySelector('option[value="terraform"]');
+		const gcloudOpt = formatSelect.querySelector('option[value="gcloud"]');
+		if (tfOpt) tfOpt.style.display = supportsTf ? 'block' : 'none';
+		if (gcloudOpt) gcloudOpt.style.display = supportsGcloud ? 'block' : 'none';
+
+		formatContainer.style.display = (supportsTf || supportsGcloud) ? 'block' : 'none';
+		if (!supportsTf && formatSelect.value === 'terraform') {
+			formatSelect.value = 'native';
+		}
+		if (!supportsGcloud && formatSelect.value === 'gcloud') {
 			formatSelect.value = 'native';
 		}
 	}
@@ -812,6 +824,8 @@ function renderVpCode() {
 	let content = bundle.native;
 	if (format === 'terraform' && bundle.terraform) {
 		content = bundle.terraform;
+	} else if (format === 'gcloud' && bundle.gcloud) {
+		content = bundle.gcloud;
 	}
 
 	if (viewer) {
@@ -845,8 +859,12 @@ function downloadVpCode() {
 	let ext = '.conf';
 	if (format === 'terraform') {
 		ext = '.tf';
+	} else if (format === 'gcloud') {
+		ext = '.sh';
 	} else if (currentVpVendor === 'aws') {
 		ext = '.json';
+	} else if (currentVpVendor === 'gcp') {
+		ext = '.cel';
 	}
 
 	const filename = `${currentVpVendor}-virtual-patches${ext}`;


### PR DESCRIPTION
## Summary

Implements complete support for **Google Cloud Armor** virtual patching across Core, Worker Web UI, and CLI.

### 1. Google Cloud Armor Virtual Patch Generator (`packages/core/src/virtual-patch/generators/gcp.ts`)
- **Native CEL (Common Expression Language)**:
  - Generates valid CEL expressions compatible with Cloud Armor custom rules:
    - Path and sensitive file extensions: `request.path.lower().endsWith('.sql')`
    - Hidden VCS directories: `request.path.matches('/\\.(?:git|svn|hg)')`
    - Query parameters: `request.query.lower().contains('union select')`
    - Request headers (User-Agent, Authorization): `request.headers['user-agent'].lower().contains(...)`
  - Joined with ` ||\n\n` in bundles to form single, valid compound CEL expressions.
  - Supports `--scope-to-path` via `request.path == '<path>' && (...)`.
  - Supports heuristic regex matching (`matches('(?i)...')`).
- **Terraform (HCL) Snippets**:
  - Generates ready-to-use `google_compute_security_policy` resources with automatic priority increments (`priority = "1000"`, `priority = "1010"`, etc.) and `preview` toggle for simulation mode.
- **gcloud CLI Snippets**:
  - Generates 1-click terminal commands:
    ```bash
    gcloud compute security-policies rules create 1000 \
        --security-policy="waf-checker-policy" \
        --expression="request.path.lower().endsWith('.sql') || request.path.matches('/\\.(?:git)')" \
        --action="deny-403" \
        --description="Block verified Sensitive Files bypass tokens"
    ```

### 2. Worker Web UI Updates (`packages/worker/src/static/`)
- Added **☁️ Cloud Armor** tab in the Virtual Patching Studio modal.
- Added `gcloud CLI Command` format option in addition to `Native (CEL)` and `Terraform (HCL)`.
- Added automatic WAF tab switching when `Google Cloud Armor` is detected during fingerprinting.
- Added `.cel` and `.sh` file extension support on download.

### 3. CLI Updates (`packages/cli/`)
- Supported `--patch gcp` in `waf-checker check <url>`.
- Supported `--waf gcp` in `waf-checker patch <file.json>`.
- Added gcloud CLI command preview output.

### 4. Tests
- Added unit tests for GCP CEL generation, simulation mode, path scoping, and bundle joining in `packages/core/test/virtual-patch.spec.ts`.
- Added unit tests for CLI `--waf gcp` in `packages/cli/test/cli.spec.ts`.
- All 353 monorepo tests passing.