### PR TITLE
feat(virtual-patch): add Azure WAF, HAProxy, Caddy, and Kubernetes Ingress rule generators

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -180,7 +180,7 @@ checkCmd
 	.option('--threshold <percent>', 'Minimum protection score percentage required to pass (e.g. 95). Exits with code 1 if score is lower')
 	.option('--reverse', 'Run deep WAF Reverse Engineering and OWASP Core Rule Set (CRS) audit', false)
 	.option('--reverse-engineer', 'Alias for --reverse', false)
-	.option('--patch [vendor]', 'Generate ready-to-deploy virtual patches (cloudflare, aws, modsecurity, nginx, gcp, all)')
+	.option('--patch [vendor]', 'Generate ready-to-deploy virtual patches (cloudflare, aws, modsecurity, nginx, gcp, azure, haproxy, caddy, k8s, all)')
 	.option('--patch-output <path>', 'File path or directory to save generated virtual patch(es) to')
 	.option('--patch-tier <tier>', 'Defense tier: strict (exact token), heuristic (regex pattern), or both', 'both')
 	.option('--patch-action <action>', 'Rule action: block or simulate', 'block')
@@ -600,7 +600,7 @@ batchCmd
 program
 	.command('patch <file>')
 	.description('Generate ready-to-deploy virtual patches from a saved JSON audit report')
-	.option('-w, --waf <vendor>', 'Target WAF vendor (cloudflare, aws, modsecurity, nginx, gcp, all)', 'all')
+	.option('-w, --waf <vendor>', 'Target WAF vendor (cloudflare, aws, modsecurity, nginx, gcp, azure, haproxy, caddy, k8s, all)', 'all')
 	.option('-t, --tier <tier>', 'Defense tier: strict, heuristic, or both', 'both')
 	.option('-a, --action <action>', 'Rule action: block or simulate', 'block')
 	.option('-o, --output <path>', 'Output file or directory to write patches to')
@@ -651,7 +651,7 @@ program
 
 			if (options.output) {
 				const outPath = path.resolve(options.output);
-				if (outPath.endsWith('.tf') || outPath.endsWith('.conf') || outPath.endsWith('.json') || outPath.endsWith('.txt')) {
+				if (outPath.endsWith('.tf') || outPath.endsWith('.conf') || outPath.endsWith('.json') || outPath.endsWith('.yaml') || outPath.endsWith('.cfg') || outPath.endsWith('.txt')) {
 					const dir = path.dirname(outPath);
 					if (dir && !fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 					const bundledText = Object.values(patchReport.bundles)
@@ -661,9 +661,27 @@ program
 					fs.writeFileSync(outPath, bundledText, 'utf8');
 				} else {
 					if (!fs.existsSync(outPath)) fs.mkdirSync(outPath, { recursive: true });
+					const extMap: Record<string, string> = {
+						cloudflare: 'conf',
+						aws: 'json',
+						modsecurity: 'conf',
+						nginx: 'conf',
+						gcp: 'cel',
+						azure: 'json',
+						haproxy: 'cfg',
+						caddy: 'caddyfile',
+						k8s: 'yaml',
+					};
 					for (const [v, b] of Object.entries(patchReport.bundles)) {
 						if (b.ruleCount === 0) continue;
-						fs.writeFileSync(path.join(outPath, `${v}-patches.conf`), b.native, 'utf8');
+						const ext = extMap[v] || 'conf';
+						fs.writeFileSync(path.join(outPath, `${v}-patches.${ext}`), b.native, 'utf8');
+						if (b.gcloud) {
+							fs.writeFileSync(path.join(outPath, `${v}-gcloud.sh`), b.gcloud, 'utf8');
+						}
+						if (b.azureCli) {
+							fs.writeFileSync(path.join(outPath, `${v}-azure-cli.sh`), b.azureCli, 'utf8');
+						}
 						if (b.terraform) {
 							fs.writeFileSync(path.join(outPath, `${v}-patches.tf`), b.terraform, 'utf8');
 						}
@@ -679,6 +697,10 @@ program
 					if (b.gcloud) {
 						console.log(`\n--- ${v.toUpperCase()} (gcloud CLI) ---`);
 						console.log(b.gcloud);
+					}
+					if (b.azureCli) {
+						console.log(`\n--- ${v.toUpperCase()} (Azure CLI) ---`);
+						console.log(b.azureCli);
 					}
 					if (b.terraform) {
 						console.log(`\n--- ${v.toUpperCase()} (Terraform) ---`);

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -837,5 +837,40 @@ describe('CLI Argument Processing', () => {
 
 			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('GCP'));
 		});
+
+		it('should generate Azure, HAProxy, Caddy, and K8s patches when specific --waf is specified', async () => {
+			vi.mocked(fs.existsSync).mockReturnValue(true);
+			vi.mocked(fs.readFileSync).mockReturnValue(
+				JSON.stringify([
+					{
+						category: 'Sensitive Files',
+						method: 'GET',
+						payload: '/dump.sql',
+						status: 200,
+						responseTime: 40,
+					},
+				])
+			);
+
+			await expect(
+				program.parseAsync(['node', 'index.js', 'patch', 'report.json', '--waf', 'azure'])
+			).resolves.toBeDefined();
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('AZURE'));
+
+			await expect(
+				program.parseAsync(['node', 'index.js', 'patch', 'report.json', '--waf', 'haproxy'])
+			).resolves.toBeDefined();
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('HAPROXY'));
+
+			await expect(
+				program.parseAsync(['node', 'index.js', 'patch', 'report.json', '--waf', 'caddy'])
+			).resolves.toBeDefined();
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('CADDY'));
+
+			await expect(
+				program.parseAsync(['node', 'index.js', 'patch', 'report.json', '--waf', 'k8s'])
+			).resolves.toBeDefined();
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('K8S'));
+		});
 	});
 });

--- a/packages/core/src/virtual-patch/generators/azure.ts
+++ b/packages/core/src/virtual-patch/generators/azure.ts
@@ -1,0 +1,278 @@
+import { AuditResultItem } from '../../reports/types';
+import { VirtualPatchOptions, GeneratedPatch } from '../types';
+import {
+	CATEGORY_HEURISTICS,
+	detectInspectionLocation,
+	escapeRegex,
+	sanitizeStrictToken,
+	escapeHclString,
+} from '../heuristics';
+
+function getAzureMatchVariable(location: 'query' | 'body' | 'header' | 'uri') {
+	switch (location) {
+		case 'header':
+			return 'RequestHeader';
+		case 'uri':
+			return 'RequestUri';
+		case 'body':
+			return 'RequestBody';
+		case 'query':
+		default:
+			return 'QueryString';
+	}
+}
+
+/**
+ * Generates Azure Front Door / Application Gateway WAF rules (JSON, Azure CLI, and Terraform).
+ */
+export function generateAzurePatches(
+	bypasses: AuditResultItem[],
+	options: VirtualPatchOptions = {}
+): GeneratedPatch[] {
+	const patches: GeneratedPatch[] = [];
+	const isSimulate = options.action === 'simulate';
+	const azureAction = isSimulate ? 'Log' : 'Block';
+	let currentPriority = options.ruleIdPrefix ? Math.floor(options.ruleIdPrefix / 1000) : 100;
+
+	const groups: Record<string, AuditResultItem[]> = {};
+	if (options.groupByCategory !== false) {
+		for (const b of bypasses) {
+			const cat = b.category || 'General Attack';
+			if (!groups[cat]) groups[cat] = [];
+			groups[cat].push(b);
+		}
+	} else {
+		bypasses.forEach((b, idx) => {
+			groups[`${b.category || 'Attack'}_${idx}`] = [b];
+		});
+	}
+
+	for (const [category, items] of Object.entries(groups)) {
+		const sampleItem = items[0];
+		const location = detectInspectionLocation(category, sampleItem.method, sampleItem.payload);
+		const matchVariable = getAzureMatchVariable(location);
+		const sanitizedCat = category.replace(/[^a-zA-Z0-9]/g, '');
+		const selector = location === 'header' ? (category === 'User-Agent' ? 'User-Agent' : 'Authorization') : undefined;
+
+		// 1. Strict Hotfix Tier
+		if (options.tier !== 'heuristic') {
+			const tokens = Array.from(new Set(items.map((i) => sanitizeStrictToken(i.payload, category)))).filter(
+				Boolean
+			);
+
+			const matchConditions: any[] = [];
+			const tfMatchBlocks: string[] = [];
+			const cliCommands: string[] = [
+				`az network front-door waf-policy rule create \\`,
+				`    --policy-name="waf-policy" \\`,
+				`    --resource-group="myResourceGroup" \\`,
+				`    --name="VirtualPatch${sanitizedCat}Strict" \\`,
+				`    --priority=${currentPriority} \\`,
+				`    --rule-type="MatchRule" \\`,
+				`    --action="${azureAction}" \\`,
+				`    --defer`,
+			];
+
+			if (location === 'uri') {
+				const exts = tokens.filter((t) => t.startsWith('.') && t !== '.git' && t !== '.svn' && t !== '.hg');
+				const vcs = tokens.filter((t) => t === '.git' || t === '.svn' || t === '.hg');
+				const files = tokens.filter((t) => !t.startsWith('.'));
+
+				if (exts.length > 0) {
+					matchConditions.push({
+						matchVariable: 'RequestUri',
+						operator: 'EndsWith',
+						negationConditon: false,
+						matchValue: exts,
+					});
+					tfMatchBlocks.push(`    match_conditions {
+      match_variable     = "RequestUri"
+      operator           = "EndsWith"
+      negation_condition = false
+      match_values       = [${exts.map((e) => `"${escapeHclString(e)}"`).join(', ')}]
+    }`);
+					cliCommands.push(
+						`az network front-door waf-policy rule match-condition add \\`,
+						`    --policy-name="waf-policy" \\`,
+						`    --resource-group="myResourceGroup" \\`,
+						`    --rule-name="VirtualPatch${sanitizedCat}Strict" \\`,
+						`    --match-variable="RequestUri" \\`,
+						`    --operator="EndsWith" \\`,
+						`    --values ${exts.map((e) => `"${e}"`).join(' ')}`
+					);
+				}
+
+				if (vcs.length > 0) {
+					const vcsRegex = `/\\.(?:${vcs.map((v) => v.slice(1)).join('|')})`;
+					matchConditions.push({
+						matchVariable: 'RequestUri',
+						operator: 'RegEx',
+						negationConditon: false,
+						matchValue: [vcsRegex],
+					});
+					tfMatchBlocks.push(`    match_conditions {
+      match_variable     = "RequestUri"
+      operator           = "RegEx"
+      negation_condition = false
+      match_values       = ["${escapeHclString(vcsRegex)}"]
+    }`);
+					cliCommands.push(
+						`az network front-door waf-policy rule match-condition add \\`,
+						`    --policy-name="waf-policy" \\`,
+						`    --resource-group="myResourceGroup" \\`,
+						`    --rule-name="VirtualPatch${sanitizedCat}Strict" \\`,
+						`    --match-variable="RequestUri" \\`,
+						`    --operator="RegEx" \\`,
+						`    --values "${vcsRegex}"`
+					);
+				}
+
+				if (files.length > 0) {
+					matchConditions.push({
+						matchVariable: 'RequestUri',
+						operator: 'EndsWith',
+						negationConditon: false,
+						matchValue: files,
+					});
+					tfMatchBlocks.push(`    match_conditions {
+      match_variable     = "RequestUri"
+      operator           = "EndsWith"
+      negation_condition = false
+      match_values       = [${files.map((f) => `"${escapeHclString(f)}"`).join(', ')}]
+    }`);
+					cliCommands.push(
+						`az network front-door waf-policy rule match-condition add \\`,
+						`    --policy-name="waf-policy" \\`,
+						`    --resource-group="myResourceGroup" \\`,
+						`    --rule-name="VirtualPatch${sanitizedCat}Strict" \\`,
+						`    --match-variable="RequestUri" \\`,
+						`    --operator="EndsWith" \\`,
+						`    --values ${files.map((f) => `"${f}"`).join(' ')}`
+					);
+				}
+			} else {
+				matchConditions.push({
+					matchVariable,
+					selector,
+					operator: 'Contains',
+					negationConditon: false,
+					matchValue: tokens,
+				});
+				tfMatchBlocks.push(`    match_conditions {
+      match_variable     = "${matchVariable}"
+      ${selector ? `selector           = "${selector}"\n      ` : ''}operator           = "Contains"
+      negation_condition = false
+      match_values       = [${tokens.map((t) => `"${escapeHclString(t)}"`).join(', ')}]
+    }`);
+				cliCommands.push(
+					`az network front-door waf-policy rule match-condition add \\`,
+					`    --policy-name="waf-policy" \\`,
+					`    --resource-group="myResourceGroup" \\`,
+					`    --rule-name="VirtualPatch${sanitizedCat}Strict" \\`,
+					`    --match-variable="${matchVariable}" \\`,
+					selector ? `    --selector="${selector}" \\\n` : '',
+					`    --operator="Contains" \\`,
+					`    --values ${tokens.map((t) => `"${t}"`).join(' ')}`
+				);
+			}
+
+			const ruleObj = {
+				name: `VirtualPatch_${sanitizedCat}_Strict`,
+				priority: currentPriority,
+				ruleType: 'MatchRule',
+				action: azureAction,
+				matchConditions,
+			};
+
+			const tfHcl = `custom_rules {
+  name      = "VirtualPatch_${sanitizedCat}_Strict"
+  priority  = ${currentPriority}
+  rule_type = "MatchRule"
+  action    = "${azureAction}"
+
+${tfMatchBlocks.join('\n\n')}
+}`;
+
+			patches.push({
+				vendor: 'azure',
+				name: `Azure WAF: ${category} (Strict Hotfix)`,
+				category,
+				tier: 'strict',
+				nativeRule: JSON.stringify(ruleObj, null, 2),
+				terraformHcl: tfHcl,
+				azureCliCommand: cliCommands.join('\n'),
+				description: `Azure WAF custom rule matching ${tokens.length} verified ${category} bypass token(s)`,
+			});
+			currentPriority += 10;
+		}
+
+		// 2. Heuristic Pattern Tier
+		if (options.tier !== 'strict') {
+			const heuristic = CATEGORY_HEURISTICS[category];
+			const rawPattern = heuristic ? heuristic.pattern : escapeRegex(items[0].payload);
+
+			const ruleObj = {
+				name: `VirtualPatch_${sanitizedCat}_Heuristic`,
+				priority: currentPriority,
+				ruleType: 'MatchRule',
+				action: azureAction,
+				matchConditions: [
+					{
+						matchVariable,
+						selector,
+						operator: 'RegEx',
+						negationConditon: false,
+						matchValue: [rawPattern],
+					},
+				],
+			};
+
+			const tfHcl = `custom_rules {
+  name      = "VirtualPatch_${sanitizedCat}_Heuristic"
+  priority  = ${currentPriority}
+  rule_type = "MatchRule"
+  action    = "${azureAction}"
+
+  match_conditions {
+    match_variable     = "${matchVariable}"
+    ${selector ? `selector           = "${selector}"\n    ` : ''}operator           = "RegEx"
+    negation_condition = false
+    match_values       = ["${escapeHclString(rawPattern)}"]
+  }
+}`;
+
+			const cliCommands = [
+				`az network front-door waf-policy rule create \\`,
+				`    --policy-name="waf-policy" \\`,
+				`    --resource-group="myResourceGroup" \\`,
+				`    --name="VirtualPatch${sanitizedCat}Heuristic" \\`,
+				`    --priority=${currentPriority} \\`,
+				`    --rule-type="MatchRule" \\`,
+				`    --action="${azureAction}" \\`,
+				`    --defer`,
+				`az network front-door waf-policy rule match-condition add \\`,
+				`    --policy-name="waf-policy" \\`,
+				`    --resource-group="myResourceGroup" \\`,
+				`    --rule-name="VirtualPatch${sanitizedCat}Heuristic" \\`,
+				`    --match-variable="${matchVariable}" \\`,
+				selector ? `    --selector="${selector}" \\\n` : '',
+				`    --operator="RegEx" \\`,
+				`    --values "${rawPattern.replace(/"/g, '\\"')}"`,
+			];
+
+			patches.push({
+				vendor: 'azure',
+				name: `Azure WAF: ${category} (Heuristic Pattern)`,
+				category,
+				tier: 'heuristic',
+				nativeRule: JSON.stringify(ruleObj, null, 2),
+				terraformHcl: tfHcl,
+				azureCliCommand: cliCommands.join('\n'),
+				description: heuristic ? heuristic.description : `Azure WAF heuristic regex defense for ${category}`,
+			});
+			currentPriority += 10;
+		}
+	}
+
+	return patches;
+}

--- a/packages/core/src/virtual-patch/generators/caddy.ts
+++ b/packages/core/src/virtual-patch/generators/caddy.ts
@@ -1,0 +1,152 @@
+import { AuditResultItem } from '../../reports/types';
+import { VirtualPatchOptions, GeneratedPatch } from '../types';
+import {
+	CATEGORY_HEURISTICS,
+	detectInspectionLocation,
+	escapeRegex,
+	sanitizeStrictToken,
+} from '../heuristics';
+
+function getUrlPath(targetUrl?: string): string | null {
+	if (!targetUrl) return null;
+	try {
+		const parsed = new URL(targetUrl);
+		return parsed.pathname !== '/' ? parsed.pathname : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Generates Caddyfile named matchers and directive blocks.
+ */
+export function generateCaddyPatches(
+	bypasses: AuditResultItem[],
+	options: VirtualPatchOptions = {}
+): GeneratedPatch[] {
+	const patches: GeneratedPatch[] = [];
+	const isSimulate = options.action === 'simulate';
+	const urlPath = options.scopeToPath ? getUrlPath(options.targetUrl) : null;
+
+	const groups: Record<string, AuditResultItem[]> = {};
+	if (options.groupByCategory !== false) {
+		for (const b of bypasses) {
+			const cat = b.category || 'General Attack';
+			if (!groups[cat]) groups[cat] = [];
+			groups[cat].push(b);
+		}
+	} else {
+		bypasses.forEach((b, idx) => {
+			groups[`${b.category || 'Attack'}_${idx}`] = [b];
+		});
+	}
+
+	for (const [category, items] of Object.entries(groups)) {
+		const sampleItem = items[0];
+		const location = detectInspectionLocation(category, sampleItem.method, sampleItem.payload);
+		const sanitizedCat = category.toLowerCase().replace(/[^a-z0-9]/g, '_');
+
+		// 1. Strict Hotfix Tier
+		if (options.tier !== 'heuristic') {
+			const tokens = Array.from(new Set(items.map((i) => sanitizeStrictToken(i.payload, category)))).filter(
+				Boolean
+			);
+
+			const matcherName = `@waf_patch_${sanitizedCat}_strict`;
+			const lines: string[] = [
+				`# --- WAF-Checker Virtual Patch: ${category} (Strict) ---`,
+				`${matcherName} {`,
+			];
+
+			if (urlPath) {
+				lines.push(`    path ${urlPath}*`);
+			}
+
+			if (location === 'uri') {
+				const exts = tokens.filter((t) => t.startsWith('.') && t !== '.git' && t !== '.svn' && t !== '.hg');
+				const vcs = tokens.filter((t) => t === '.git' || t === '.svn' || t === '.hg');
+				const files = tokens.filter((t) => !t.startsWith('.'));
+
+				if (exts.length > 0) {
+					lines.push(`    path *${exts.join(' *')}`);
+				}
+				if (vcs.length > 0) {
+					lines.push(`    path ${vcs.map((v) => `*/${v}/*`).join(' ')}`);
+				}
+				if (files.length > 0) {
+					lines.push(`    path ${files.map((f) => (f.startsWith('/') ? f : `/${f}`)).join(' ')}`);
+				}
+			} else if (location === 'header') {
+				const hdrName = category === 'User-Agent' ? 'User-Agent' : 'Authorization';
+				for (const tok of tokens) {
+					lines.push(`    header ${hdrName} *${tok}*`);
+				}
+			} else {
+				for (const tok of tokens) {
+					lines.push(`    query *${tok.replace(/\s+/g, '*')}*`);
+				}
+			}
+
+			lines.push(`}`);
+			if (isSimulate) {
+				lines.push(`header ${matcherName} X-WAF-Simulation "blocked"`);
+			} else {
+				lines.push(`respond ${matcherName} 403`);
+			}
+
+			const nativeRule = lines.join('\n');
+			patches.push({
+				vendor: 'caddy',
+				name: `Caddy: ${category} (Strict Hotfix)`,
+				category,
+				tier: 'strict',
+				nativeRule,
+				description: `Caddy named matcher matching ${tokens.length} verified ${category} bypass token(s)`,
+			});
+		}
+
+		// 2. Heuristic Pattern Tier
+		if (options.tier !== 'strict') {
+			const heuristic = CATEGORY_HEURISTICS[category];
+			const rawPattern = heuristic ? heuristic.pattern : escapeRegex(items[0].payload);
+
+			const matcherName = `@waf_patch_${sanitizedCat}_heuristic`;
+			const lines: string[] = [
+				`# --- WAF-Checker Virtual Patch: ${category} (Heuristic) ---`,
+				`${matcherName} {`,
+			];
+
+			if (urlPath) {
+				lines.push(`    path ${urlPath}*`);
+			}
+
+			if (location === 'uri') {
+				lines.push(`    path_regexp "(?i)${rawPattern.replace(/"/g, '\\"')}"`);
+			} else if (location === 'header') {
+				const hdrName = category === 'User-Agent' ? 'User-Agent' : 'Authorization';
+				lines.push(`    header_regexp ${hdrName} "(?i)${rawPattern.replace(/"/g, '\\"')}"`);
+			} else {
+				lines.push(`    query_regexp "(?i)${rawPattern.replace(/"/g, '\\"')}"`);
+			}
+
+			lines.push(`}`);
+			if (isSimulate) {
+				lines.push(`header ${matcherName} X-WAF-Simulation "blocked"`);
+			} else {
+				lines.push(`respond ${matcherName} 403`);
+			}
+
+			const nativeRule = lines.join('\n');
+			patches.push({
+				vendor: 'caddy',
+				name: `Caddy: ${category} (Heuristic Pattern)`,
+				category,
+				tier: 'heuristic',
+				nativeRule,
+				description: heuristic ? heuristic.description : `Caddy regex matcher defense for ${category}`,
+			});
+		}
+	}
+
+	return patches;
+}

--- a/packages/core/src/virtual-patch/generators/haproxy.ts
+++ b/packages/core/src/virtual-patch/generators/haproxy.ts
@@ -1,0 +1,161 @@
+import { AuditResultItem } from '../../reports/types';
+import { VirtualPatchOptions, GeneratedPatch } from '../types';
+import {
+	CATEGORY_HEURISTICS,
+	detectInspectionLocation,
+	escapeRegex,
+	sanitizeStrictToken,
+} from '../heuristics';
+
+function getUrlPath(targetUrl?: string): string | null {
+	if (!targetUrl) return null;
+	try {
+		const parsed = new URL(targetUrl);
+		return parsed.pathname !== '/' ? parsed.pathname : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Generates HAProxy ACL configuration snippets (native haproxy.cfg).
+ */
+export function generateHAProxyPatches(
+	bypasses: AuditResultItem[],
+	options: VirtualPatchOptions = {}
+): GeneratedPatch[] {
+	const patches: GeneratedPatch[] = [];
+	const isSimulate = options.action === 'simulate';
+	const urlPath = options.scopeToPath ? getUrlPath(options.targetUrl) : null;
+
+	const groups: Record<string, AuditResultItem[]> = {};
+	if (options.groupByCategory !== false) {
+		for (const b of bypasses) {
+			const cat = b.category || 'General Attack';
+			if (!groups[cat]) groups[cat] = [];
+			groups[cat].push(b);
+		}
+	} else {
+		bypasses.forEach((b, idx) => {
+			groups[`${b.category || 'Attack'}_${idx}`] = [b];
+		});
+	}
+
+	for (const [category, items] of Object.entries(groups)) {
+		const sampleItem = items[0];
+		const location = detectInspectionLocation(category, sampleItem.method, sampleItem.payload);
+		const sanitizedCat = category.toLowerCase().replace(/[^a-z0-9]/g, '_');
+
+		// 1. Strict Hotfix Tier
+		if (options.tier !== 'heuristic') {
+			const tokens = Array.from(new Set(items.map((i) => sanitizeStrictToken(i.payload, category)))).filter(
+				Boolean
+			);
+
+			const aclLines: string[] = [
+				`# --- WAF-Checker Virtual Patch: ${category} (Strict) ---`,
+			];
+			const aclConditionNames: string[] = [];
+
+			if (urlPath) {
+				aclLines.push(`acl is_scoped_path_${sanitizedCat} path_beg ${urlPath}`);
+			}
+
+			if (location === 'uri') {
+				const exts = tokens.filter((t) => t.startsWith('.') && t !== '.git' && t !== '.svn' && t !== '.hg');
+				const vcs = tokens.filter((t) => t === '.git' || t === '.svn' || t === '.hg');
+				const files = tokens.filter((t) => !t.startsWith('.'));
+
+				if (exts.length > 0) {
+					const aclName = `is_${sanitizedCat}_ext`;
+					aclLines.push(`acl ${aclName} path_end -i ${exts.join(' ')}`);
+					aclConditionNames.push(aclName);
+				}
+				if (vcs.length > 0) {
+					const aclName = `is_${sanitizedCat}_vcs`;
+					aclLines.push(`acl ${aclName} path_beg -i ${vcs.map((v) => `/${v}`).join(' ')}`);
+					aclConditionNames.push(aclName);
+				}
+				if (files.length > 0) {
+					const aclName = `is_${sanitizedCat}_files`;
+					aclLines.push(`acl ${aclName} path_end -i ${files.map((f) => (f.startsWith('/') ? f : `/${f}`)).join(' ')}`);
+					aclConditionNames.push(aclName);
+				}
+			} else if (location === 'header') {
+				const hdrName = category === 'User-Agent' ? 'User-Agent' : 'Authorization';
+				const aclName = `is_${sanitizedCat}_hdr`;
+				aclLines.push(`acl ${aclName} req.hdr(${hdrName}) -m sub -i ${tokens.map((t) => `"${t.replace(/"/g, '\\"')}"`).join(' ')}`);
+				aclConditionNames.push(aclName);
+			} else {
+				// Query or Body
+				const aclName = `is_${sanitizedCat}_query`;
+				aclLines.push(`acl ${aclName} query -m sub -i ${tokens.map((t) => `"${t.replace(/"/g, '\\"')}"`).join(' ')}`);
+				aclConditionNames.push(aclName);
+			}
+
+			if (aclConditionNames.length > 0) {
+				const condition = aclConditionNames.join(' or ');
+				const fullCond = urlPath ? `is_scoped_path_${sanitizedCat} { ${condition} }` : condition;
+
+				if (isSimulate) {
+					aclLines.push(`http-request set-header X-WAF-Simulation "blocked" if ${fullCond}`);
+				} else {
+					aclLines.push(`http-request deny deny_status 403 if ${fullCond}`);
+				}
+			}
+
+			const nativeRule = aclLines.join('\n');
+			patches.push({
+				vendor: 'haproxy',
+				name: `HAProxy: ${category} (Strict Hotfix)`,
+				category,
+				tier: 'strict',
+				nativeRule,
+				description: `HAProxy ACL directive matching ${tokens.length} verified ${category} bypass token(s)`,
+			});
+		}
+
+		// 2. Heuristic Pattern Tier
+		if (options.tier !== 'strict') {
+			const heuristic = CATEGORY_HEURISTICS[category];
+			const rawPattern = heuristic ? heuristic.pattern : escapeRegex(items[0].payload);
+
+			const aclLines: string[] = [
+				`# --- WAF-Checker Virtual Patch: ${category} (Heuristic) ---`,
+			];
+			const aclName = `is_${sanitizedCat}_rx`;
+
+			if (urlPath) {
+				aclLines.push(`acl is_scoped_path_${sanitizedCat} path_beg ${urlPath}`);
+			}
+
+			if (location === 'uri') {
+				aclLines.push(`acl ${aclName} path_reg -i "${rawPattern.replace(/"/g, '\\"')}"`);
+			} else if (location === 'header') {
+				const hdrName = category === 'User-Agent' ? 'User-Agent' : 'Authorization';
+				aclLines.push(`acl ${aclName} req.hdr_reg(${hdrName}) -i "${rawPattern.replace(/"/g, '\\"')}"`);
+			} else {
+				aclLines.push(`acl ${aclName} query_reg -i "${rawPattern.replace(/"/g, '\\"')}"`);
+			}
+
+			const fullCond = urlPath ? `is_scoped_path_${sanitizedCat} ${aclName}` : aclName;
+			if (isSimulate) {
+				aclLines.push(`http-request set-header X-WAF-Simulation "blocked" if ${fullCond}`);
+			} else {
+				aclLines.push(`http-request deny deny_status 403 if ${fullCond}`);
+			}
+
+			const nativeRule = aclLines.join('\n');
+			patches.push({
+				vendor: 'haproxy',
+				name: `HAProxy: ${category} (Heuristic Pattern)`,
+				category,
+				tier: 'heuristic',
+				nativeRule,
+				description: heuristic ? heuristic.description : `HAProxy regex ACL defense for ${category}`,
+			});
+		}
+	}
+
+	return patches;
+}

--- a/packages/core/src/virtual-patch/generators/k8s.ts
+++ b/packages/core/src/virtual-patch/generators/k8s.ts
@@ -1,0 +1,192 @@
+import { AuditResultItem } from '../../reports/types';
+import { VirtualPatchOptions, GeneratedPatch } from '../types';
+import {
+	CATEGORY_HEURISTICS,
+	detectInspectionLocation,
+	escapeRegex,
+	sanitizeStrictToken,
+} from '../heuristics';
+
+function getHostname(targetUrl?: string): string {
+	if (!targetUrl) return 'app.example.com';
+	try {
+		return new URL(targetUrl).hostname || 'app.example.com';
+	} catch {
+		return 'app.example.com';
+	}
+}
+
+function escapeNginxRegex(str: string): string {
+	return str.replace(/"/g, '\\"');
+}
+
+/**
+ * Generates Kubernetes Ingress YAML manifests with Ingress-NGINX security server-snippets.
+ */
+export function generateK8sPatches(
+	bypasses: AuditResultItem[],
+	options: VirtualPatchOptions = {}
+): GeneratedPatch[] {
+	const patches: GeneratedPatch[] = [];
+	const isSimulate = options.action === 'simulate';
+	const actionSnippet = isSimulate
+		? 'add_header X-WAF-Simulation-Triggered "1" always;'
+		: 'return 403;';
+	const host = getHostname(options.targetUrl);
+
+	const groups: Record<string, AuditResultItem[]> = {};
+	if (options.groupByCategory !== false) {
+		for (const b of bypasses) {
+			const cat = b.category || 'General Attack';
+			if (!groups[cat]) groups[cat] = [];
+			groups[cat].push(b);
+		}
+	} else {
+		bypasses.forEach((b, idx) => {
+			groups[`${b.category || 'Attack'}_${idx}`] = [b];
+		});
+	}
+
+	for (const [category, items] of Object.entries(groups)) {
+		const sampleItem = items[0];
+		const location = detectInspectionLocation(category, sampleItem.method, sampleItem.payload);
+		const sanitizedCat = category.toLowerCase().replace(/[^a-z0-9]/g, '-');
+
+		// 1. Strict Hotfix Tier
+		if (options.tier !== 'heuristic') {
+			const tokens = Array.from(new Set(items.map((i) => sanitizeStrictToken(i.payload, category)))).filter(
+				Boolean
+			);
+
+			const snippetLines: string[] = [];
+			if (location === 'uri') {
+				const isVcs = (t: string) => t === '.git' || t === '.svn' || t === '.hg';
+				const extTokens = tokens
+					.filter((t) => t.startsWith('.') && !isVcs(t) && !t.includes('/'))
+					.map((t) => t.slice(1));
+				const vcsTokens = tokens.filter(isVcs).map((t) => t.slice(1));
+				const fileTokens = tokens
+					.filter((t) => !t.startsWith('.'))
+					.map((t) => t.replace(/^\/+/, ''));
+
+				if (extTokens.length > 0) {
+					snippetLines.push(
+						`location ~* \\.(${extTokens.join('|')})$ {`,
+						`    ${actionSnippet}`,
+						`}`
+					);
+				}
+				if (vcsTokens.length > 0) {
+					snippetLines.push(
+						`location ~ /\\.(?:${vcsTokens.join('|')}) {`,
+						`    ${actionSnippet}`,
+						`}`
+					);
+				}
+				if (fileTokens.length > 0) {
+					const escapedFiles = fileTokens.map((f) => escapeNginxRegex(escapeRegex(f))).join('|');
+					snippetLines.push(
+						`location ~* /(${escapedFiles}) {`,
+						`    ${actionSnippet}`,
+						`}`
+					);
+				}
+			} else if (location === 'header') {
+				const nginxVar = category === 'User-Agent' ? '$http_user_agent' : '$http_authorization';
+				const escapedAlternation = tokens.map((t) => escapeNginxRegex(escapeRegex(t))).join('|');
+				snippetLines.push(
+					`if (${nginxVar} ~* "(${escapedAlternation})") {`,
+					`    ${actionSnippet}`,
+					`}`
+				);
+			} else {
+				const escapedAlternation = tokens.map((t) => escapeNginxRegex(escapeRegex(t))).join('|');
+				snippetLines.push(
+					`if ($query_string ~* "(${escapedAlternation})") {`,
+					`    ${actionSnippet}`,
+					`}`
+				);
+			}
+
+			const indentedSnippet = snippetLines.map((l) => `      ${l}`).join('\n');
+			const manifest = `apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: waf-patch-${sanitizedCat}-strict
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/server-snippet: |
+${indentedSnippet}
+spec:
+  rules:
+  - host: ${host}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-service
+            port:
+              number: 80`;
+
+			patches.push({
+				vendor: 'k8s',
+				name: `Kubernetes Ingress: ${category} (Strict Hotfix)`,
+				category,
+				tier: 'strict',
+				nativeRule: manifest,
+				description: `K8s Ingress YAML manifest matching ${tokens.length} verified ${category} bypass token(s)`,
+			});
+		}
+
+		// 2. Heuristic Pattern Tier
+		if (options.tier !== 'strict') {
+			const heuristic = CATEGORY_HEURISTICS[category];
+			const rawPattern = heuristic ? heuristic.pattern : escapeRegex(items[0].payload);
+			const escapedPattern = escapeNginxRegex(rawPattern);
+
+			let snippet = '';
+			if (location === 'uri') {
+				snippet = `location ~* "${escapedPattern}" {\n          ${actionSnippet}\n      }`;
+			} else if (location === 'header') {
+				const nginxVar = category === 'User-Agent' ? '$http_user_agent' : '$http_authorization';
+				snippet = `if (${nginxVar} ~* "${escapedPattern}") {\n          ${actionSnippet}\n      }`;
+			} else {
+				snippet = `if ($query_string ~* "${escapedPattern}") {\n          ${actionSnippet}\n      }`;
+			}
+
+			const manifest = `apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: waf-patch-${sanitizedCat}-heuristic
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/server-snippet: |
+      ${snippet}
+spec:
+  rules:
+  - host: ${host}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-service
+            port:
+              number: 80`;
+
+			patches.push({
+				vendor: 'k8s',
+				name: `Kubernetes Ingress: ${category} (Heuristic Pattern)`,
+				category,
+				tier: 'heuristic',
+				nativeRule: manifest,
+				description: heuristic ? heuristic.description : `K8s Ingress regex defense for ${category}`,
+			});
+		}
+	}
+
+	return patches;
+}

--- a/packages/core/src/virtual-patch/index.ts
+++ b/packages/core/src/virtual-patch/index.ts
@@ -11,6 +11,10 @@ import { generateAwsPatches } from './generators/aws';
 import { generateModSecurityPatches } from './generators/modsecurity';
 import { generateNginxPatches } from './generators/nginx';
 import { generateGcpPatches } from './generators/gcp';
+import { generateAzurePatches } from './generators/azure';
+import { generateHAProxyPatches } from './generators/haproxy';
+import { generateCaddyPatches } from './generators/caddy';
+import { generateK8sPatches } from './generators/k8s';
 
 export * from './types';
 export * from './heuristics';
@@ -19,6 +23,10 @@ export * from './generators/aws';
 export * from './generators/modsecurity';
 export * from './generators/nginx';
 export * from './generators/gcp';
+export * from './generators/azure';
+export * from './generators/haproxy';
+export * from './generators/caddy';
+export * from './generators/k8s';
 
 /**
  * Filters audit results to isolate confirmed WAF bypasses (HTTP 200)
@@ -69,13 +77,25 @@ export function generateVirtualPatches(
 		if (targetVendor === 'all' || targetVendor === 'gcp') {
 			allPatches.push(...generateGcpPatches(bypasses, options));
 		}
+		if (targetVendor === 'all' || targetVendor === 'azure') {
+			allPatches.push(...generateAzurePatches(bypasses, options));
+		}
+		if (targetVendor === 'all' || targetVendor === 'haproxy') {
+			allPatches.push(...generateHAProxyPatches(bypasses, options));
+		}
+		if (targetVendor === 'all' || targetVendor === 'caddy') {
+			allPatches.push(...generateCaddyPatches(bypasses, options));
+		}
+		if (targetVendor === 'all' || targetVendor === 'k8s') {
+			allPatches.push(...generateK8sPatches(bypasses, options));
+		}
 	}
 
 	// Build vendor-level bundle strings for easy 1-click copy / download
 	const bundles: Record<string, VendorPatchBundle> = {};
 	const vendorsToBundle: PatchVendor[] =
 		targetVendor === 'all'
-			? ['cloudflare', 'aws', 'modsecurity', 'nginx', 'gcp']
+			? ['cloudflare', 'aws', 'modsecurity', 'nginx', 'gcp', 'azure', 'haproxy', 'caddy', 'k8s']
 			: [targetVendor];
 
 	for (const v of vendorsToBundle) {
@@ -87,6 +107,9 @@ export function generateVirtualPatches(
 		const gcloudParts = vendorPatches
 			.filter((p) => p.gcloudCommand)
 			.map((p) => p.gcloudCommand!);
+		const azureCliParts = vendorPatches
+			.filter((p) => p.azureCliCommand)
+			.map((p) => p.azureCliCommand!);
 
 		let nativeJoined = '';
 		if (v === 'cloudflare') {
@@ -102,8 +125,11 @@ export function generateVirtualPatches(
 				nativeParts.length <= 1
 					? nativeParts[0] || ''
 					: nativeParts.join(' ||\n\n');
-		} else if (v === 'aws') {
-			// Format multiple AWS WAF rules as a valid JSON array for AWS CLI / CloudFormation
+		} else if (v === 'k8s') {
+			// In Kubernetes, separate manifests with standard '---'
+			nativeJoined = nativeParts.join('\n---\n');
+		} else if (v === 'aws' || v === 'azure') {
+			// Format multiple JSON rules as a valid JSON array
 			if (nativeParts.length <= 1) {
 				nativeJoined = nativeParts[0] || '';
 			} else {
@@ -123,6 +149,7 @@ export function generateVirtualPatches(
 			native: nativeJoined,
 			terraform: tfParts.length > 0 ? tfParts.join('\n\n') : undefined,
 			gcloud: gcloudParts.length > 0 ? gcloudParts.join('\n\n') : undefined,
+			azureCli: azureCliParts.length > 0 ? azureCliParts.join('\n\n') : undefined,
 			ruleCount: vendorPatches.length,
 		};
 	}

--- a/packages/core/src/virtual-patch/types.ts
+++ b/packages/core/src/virtual-patch/types.ts
@@ -1,6 +1,16 @@
 import { AuditResultItem } from '../reports/types';
 
-export type PatchVendor = 'cloudflare' | 'aws' | 'modsecurity' | 'nginx' | 'gcp' | 'all';
+export type PatchVendor =
+	| 'cloudflare'
+	| 'aws'
+	| 'modsecurity'
+	| 'nginx'
+	| 'gcp'
+	| 'azure'
+	| 'haproxy'
+	| 'caddy'
+	| 'k8s'
+	| 'all';
 export type PatchTier = 'strict' | 'heuristic' | 'both';
 export type PatchAction = 'block' | 'simulate';
 
@@ -46,7 +56,7 @@ export interface VirtualPatchOptions {
 	ruleIdPrefix?: number;
 
 	/**
-	 * Include Terraform HCL snippets where supported (Cloudflare, AWS WAF & GCP Cloud Armor).
+	 * Include Terraform HCL snippets where supported (Cloudflare, AWS WAF, GCP & Azure).
 	 * Default: true.
 	 */
 	includeTerraform?: boolean;
@@ -72,6 +82,7 @@ export interface GeneratedPatch {
 	nativeRule: string;
 	terraformHcl?: string;
 	gcloudCommand?: string;
+	azureCliCommand?: string;
 	description: string;
 }
 
@@ -80,6 +91,7 @@ export interface VendorPatchBundle {
 	native: string;
 	terraform?: string;
 	gcloud?: string;
+	azureCli?: string;
 	ruleCount: number;
 }
 

--- a/packages/core/test/virtual-patch.spec.ts
+++ b/packages/core/test/virtual-patch.spec.ts
@@ -124,12 +124,20 @@ describe('Virtual Patching & Rule Generator', () => {
 			expect(report.bundles.modsecurity).toBeDefined();
 			expect(report.bundles.nginx).toBeDefined();
 			expect(report.bundles.gcp).toBeDefined();
+			expect(report.bundles.azure).toBeDefined();
+			expect(report.bundles.haproxy).toBeDefined();
+			expect(report.bundles.caddy).toBeDefined();
+			expect(report.bundles.k8s).toBeDefined();
 
 			expect(report.bundles.cloudflare.ruleCount).toBeGreaterThan(0);
 			expect(report.bundles.aws.ruleCount).toBeGreaterThan(0);
 			expect(report.bundles.modsecurity.ruleCount).toBeGreaterThan(0);
 			expect(report.bundles.nginx.ruleCount).toBeGreaterThan(0);
 			expect(report.bundles.gcp.ruleCount).toBeGreaterThan(0);
+			expect(report.bundles.azure.ruleCount).toBeGreaterThan(0);
+			expect(report.bundles.haproxy.ruleCount).toBeGreaterThan(0);
+			expect(report.bundles.caddy.ruleCount).toBeGreaterThan(0);
+			expect(report.bundles.k8s.ruleCount).toBeGreaterThan(0);
 		});
 
 		it('should filter by specific vendor when requested', () => {
@@ -476,6 +484,110 @@ describe('Virtual Patching & Rule Generator', () => {
 			expect(gcpBundle.native).toContain(' ||\n\n');
 			expect(gcpBundle.terraform).toContain('google_compute_security_policy');
 			expect(gcpBundle.gcloud).toContain('gcloud compute security-policies');
+		});
+	});
+
+	describe('Azure WAF Generator', () => {
+		const sensitiveFiles: AuditResultItem[] = [
+			{ category: 'Sensitive Files', method: 'GET', payload: '/dump.sql', status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/backup.zip', status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/.git/config', status: 200, responseTime: 20 },
+		];
+
+		it('should generate valid Azure WAF custom rules, Terraform, and Azure CLI commands', () => {
+			const report = generateVirtualPatches(sensitiveFiles, { vendor: 'azure', tier: 'strict' });
+			const patch = report.patches[0];
+			expect(patch.vendor).toBe('azure');
+			expect(patch.nativeRule).toContain('"operator": "EndsWith"');
+			expect(patch.nativeRule).toContain('.sql');
+			expect(patch.nativeRule).toContain('"operator": "RegEx"');
+			expect(patch.terraformHcl).toContain('custom_rules');
+			expect(patch.terraformHcl).toContain('operator           = "EndsWith"');
+			expect(patch.azureCliCommand).toContain('az network front-door waf-policy rule create');
+			expect(patch.azureCliCommand).toContain('--action="Block"');
+		});
+
+		it('should support simulation mode (action = Log) in Azure WAF', () => {
+			const report = generateVirtualPatches(mockBypasses, { vendor: 'azure', action: 'simulate' });
+			const patch = report.patches[0];
+			expect(patch.nativeRule).toContain('"action": "Log"');
+			expect(patch.terraformHcl).toContain('action    = "Log"');
+			expect(patch.azureCliCommand).toContain('--action="Log"');
+		});
+	});
+
+	describe('HAProxy Generator', () => {
+		const sensitiveFiles: AuditResultItem[] = [
+			{ category: 'Sensitive Files', method: 'GET', payload: '/dump.sql', status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/.git/config', status: 200, responseTime: 20 },
+		];
+
+		it('should generate valid HAProxy ACL directives', () => {
+			const report = generateVirtualPatches(sensitiveFiles, { vendor: 'haproxy', tier: 'strict' });
+			const patch = report.patches[0];
+			expect(patch.vendor).toBe('haproxy');
+			expect(patch.nativeRule).toContain('acl is_sensitive_files_ext path_end -i .sql');
+			expect(patch.nativeRule).toContain('acl is_sensitive_files_vcs path_beg -i /.git');
+			expect(patch.nativeRule).toContain('http-request deny deny_status 403');
+		});
+
+		it('should support simulation mode in HAProxy', () => {
+			const report = generateVirtualPatches(sensitiveFiles, { vendor: 'haproxy', action: 'simulate' });
+			const patch = report.patches[0];
+			expect(patch.nativeRule).toContain('http-request set-header X-WAF-Simulation "blocked"');
+		});
+	});
+
+	describe('Caddy Generator', () => {
+		const sensitiveFiles: AuditResultItem[] = [
+			{ category: 'Sensitive Files', method: 'GET', payload: '/dump.sql', status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/.git/config', status: 200, responseTime: 20 },
+		];
+
+		it('should generate valid Caddyfile named matchers', () => {
+			const report = generateVirtualPatches(sensitiveFiles, { vendor: 'caddy', tier: 'strict' });
+			const patch = report.patches[0];
+			expect(patch.vendor).toBe('caddy');
+			expect(patch.nativeRule).toContain('@waf_patch_sensitive_files_strict');
+			expect(patch.nativeRule).toContain('path *.sql');
+			expect(patch.nativeRule).toContain('path */.git/*');
+			expect(patch.nativeRule).toContain('respond @waf_patch_sensitive_files_strict 403');
+		});
+
+		it('should support simulation mode in Caddy', () => {
+			const report = generateVirtualPatches(sensitiveFiles, { vendor: 'caddy', action: 'simulate' });
+			const patch = report.patches[0];
+			expect(patch.nativeRule).toContain('header @waf_patch_sensitive_files_strict X-WAF-Simulation "blocked"');
+		});
+	});
+
+	describe('Kubernetes Ingress Generator', () => {
+		const sensitiveFiles: AuditResultItem[] = [
+			{ category: 'Sensitive Files', method: 'GET', payload: '/dump.sql', status: 200, responseTime: 20 },
+			{ category: 'Sensitive Files', method: 'GET', payload: '/.git/config', status: 200, responseTime: 20 },
+		];
+
+		it('should generate valid Kubernetes Ingress YAML manifests', () => {
+			const report = generateVirtualPatches(sensitiveFiles, {
+				vendor: 'k8s',
+				tier: 'strict',
+				targetUrl: 'https://security.example.com',
+			});
+			const patch = report.patches[0];
+			expect(patch.vendor).toBe('k8s');
+			expect(patch.nativeRule).toContain('kind: Ingress');
+			expect(patch.nativeRule).toContain('nginx.ingress.kubernetes.io/server-snippet:');
+			expect(patch.nativeRule).toContain('location ~* \\.(sql)$');
+			expect(patch.nativeRule).toContain('location ~ /\\.(?:git)');
+			expect(patch.nativeRule).toContain('host: security.example.com');
+		});
+
+		it('should join multiple K8s manifests with --- in bundle', () => {
+			const report = generateVirtualPatches(mockBypasses, { vendor: 'k8s', tier: 'both' });
+			const k8sBundle = report.bundles.k8s;
+			expect(k8sBundle).toBeDefined();
+			expect(k8sBundle.ruleCount).toBeGreaterThan(1);
+			expect(k8sBundle.native).toContain('\n---\n');
 		});
 	});
 });

--- a/packages/worker/src/static/index.html
+++ b/packages/worker/src/static/index.html
@@ -455,13 +455,25 @@
 								<button class="nav-link" id="tab-aws" onclick="selectVpVendor('aws')">🟧 AWS WAF v2</button>
 							</li>
 							<li class="nav-item" role="presentation">
+								<button class="nav-link" id="tab-gcp" onclick="selectVpVendor('gcp')">☁️ Cloud Armor</button>
+							</li>
+							<li class="nav-item" role="presentation">
+								<button class="nav-link" id="tab-azure" onclick="selectVpVendor('azure')">🔷 Azure WAF</button>
+							</li>
+							<li class="nav-item" role="presentation">
 								<button class="nav-link" id="tab-modsecurity" onclick="selectVpVendor('modsecurity')">🛡️ ModSecurity</button>
 							</li>
 							<li class="nav-item" role="presentation">
 								<button class="nav-link" id="tab-nginx" onclick="selectVpVendor('nginx')">🟩 NGINX</button>
 							</li>
 							<li class="nav-item" role="presentation">
-								<button class="nav-link" id="tab-gcp" onclick="selectVpVendor('gcp')">☁️ Cloud Armor</button>
+								<button class="nav-link" id="tab-haproxy" onclick="selectVpVendor('haproxy')">🔶 HAProxy</button>
+							</li>
+							<li class="nav-item" role="presentation">
+								<button class="nav-link" id="tab-caddy" onclick="selectVpVendor('caddy')">🚀 Caddy</button>
+							</li>
+							<li class="nav-item" role="presentation">
+								<button class="nav-link" id="tab-k8s" onclick="selectVpVendor('k8s')">☸️ K8s Ingress</button>
 							</li>
 						</ul>
 
@@ -493,9 +505,10 @@
 							<div class="col-auto" id="vpFormatContainer">
 								<label class="form-label mb-0 small fw-bold">Format:</label>
 								<select id="vpFormatSelect" class="form-select form-select-sm" onchange="refreshVpCode()">
-									<option value="native" selected>Native Rules</option>
+									<option value="native" selected>Native Rules / Config</option>
 									<option value="terraform">Terraform (HCL)</option>
 									<option value="gcloud">gcloud CLI Command</option>
+									<option value="azureCli">Azure CLI Command</option>
 								</select>
 							</div>
 							<div class="col-auto ms-auto">

--- a/packages/worker/src/static/main.js
+++ b/packages/worker/src/static/main.js
@@ -696,6 +696,10 @@ async function showVirtualPatchModal(initialScope) {
 		currentVpVendor = 'aws';
 	} else if (detectedWAF.includes('cloud armor') || detectedWAF.includes('gcp') || detectedWAF.includes('google')) {
 		currentVpVendor = 'gcp';
+	} else if (detectedWAF.includes('azure') || detectedWAF.includes('front door')) {
+		currentVpVendor = 'azure';
+	} else if (detectedWAF.includes('haproxy')) {
+		currentVpVendor = 'haproxy';
 	} else if (detectedWAF.includes('modsecurity') || detectedWAF.includes('coraza')) {
 		currentVpVendor = 'modsecurity';
 	} else if (detectedWAF.includes('nginx')) {
@@ -708,7 +712,7 @@ async function showVirtualPatchModal(initialScope) {
 }
 
 function updateVpTabs() {
-	const vendors = ['cloudflare', 'aws', 'modsecurity', 'nginx', 'gcp'];
+	const vendors = ['cloudflare', 'aws', 'gcp', 'azure', 'modsecurity', 'nginx', 'haproxy', 'caddy', 'k8s'];
 	vendors.forEach((v) => {
 		const btn = document.getElementById(`tab-${v}`);
 		if (btn) {
@@ -720,23 +724,29 @@ function updateVpTabs() {
 		}
 	});
 
-	// Toggle Terraform and gcloud option visibility
+	// Toggle Terraform, gcloud, and azureCli option visibility
 	const formatContainer = document.getElementById('vpFormatContainer');
 	const formatSelect = document.getElementById('vpFormatSelect');
 	if (formatContainer && formatSelect) {
-		const supportsTf = currentVpVendor === 'cloudflare' || currentVpVendor === 'aws' || currentVpVendor === 'gcp';
+		const supportsTf = currentVpVendor === 'cloudflare' || currentVpVendor === 'aws' || currentVpVendor === 'gcp' || currentVpVendor === 'azure';
 		const supportsGcloud = currentVpVendor === 'gcp';
+		const supportsAzureCli = currentVpVendor === 'azure';
 
 		const tfOpt = formatSelect.querySelector('option[value="terraform"]');
 		const gcloudOpt = formatSelect.querySelector('option[value="gcloud"]');
+		const azureCliOpt = formatSelect.querySelector('option[value="azureCli"]');
 		if (tfOpt) tfOpt.style.display = supportsTf ? 'block' : 'none';
 		if (gcloudOpt) gcloudOpt.style.display = supportsGcloud ? 'block' : 'none';
+		if (azureCliOpt) azureCliOpt.style.display = supportsAzureCli ? 'block' : 'none';
 
-		formatContainer.style.display = (supportsTf || supportsGcloud) ? 'block' : 'none';
+		formatContainer.style.display = (supportsTf || supportsGcloud || supportsAzureCli) ? 'block' : 'none';
 		if (!supportsTf && formatSelect.value === 'terraform') {
 			formatSelect.value = 'native';
 		}
 		if (!supportsGcloud && formatSelect.value === 'gcloud') {
+			formatSelect.value = 'native';
+		}
+		if (!supportsAzureCli && formatSelect.value === 'azureCli') {
 			formatSelect.value = 'native';
 		}
 	}
@@ -826,6 +836,8 @@ function renderVpCode() {
 		content = bundle.terraform;
 	} else if (format === 'gcloud' && bundle.gcloud) {
 		content = bundle.gcloud;
+	} else if (format === 'azureCli' && bundle.azureCli) {
+		content = bundle.azureCli;
 	}
 
 	if (viewer) {
@@ -859,12 +871,18 @@ function downloadVpCode() {
 	let ext = '.conf';
 	if (format === 'terraform') {
 		ext = '.tf';
-	} else if (format === 'gcloud') {
+	} else if (format === 'gcloud' || format === 'azureCli') {
 		ext = '.sh';
-	} else if (currentVpVendor === 'aws') {
+	} else if (currentVpVendor === 'aws' || currentVpVendor === 'azure') {
 		ext = '.json';
 	} else if (currentVpVendor === 'gcp') {
 		ext = '.cel';
+	} else if (currentVpVendor === 'haproxy') {
+		ext = '.cfg';
+	} else if (currentVpVendor === 'caddy') {
+		ext = '.caddyfile';
+	} else if (currentVpVendor === 'k8s') {
+		ext = '.yaml';
 	}
 
 	const filename = `${currentVpVendor}-virtual-patches${ext}`;


### PR DESCRIPTION
## Summary

Extends the Virtual Patching engine to support 4 major enterprise and cloud-native WAF / reverse-proxy platforms:

### 1. Azure Front Door & Application Gateway WAF (`azure`)
- **JSON Rule Definitions**: Formats clean custom rule match conditions (`EndsWith`, `Contains`, `RegEx`) with automatic priority increments. Bundles format as valid JSON arrays.
- **Terraform (HCL)**: Generates `custom_rules` blocks for `azurerm_web_application_firewall_policy` and `azurerm_cdn_frontdoor_firewall_policy`.
- **Azure CLI Commands**: Generates executable `az network front-door waf-policy rule create` and `match-condition add` commands.

### 2. HAProxy (`haproxy`)
- **Native ACLs**: Ultra-fast, zero-overhead HAProxy ACLs for `haproxy.cfg`:
  - `path_end -i` for sensitive file extensions (`.sql`, `.env`, `.bak`, `.key`, `.zip`)
  - `path_beg -i` for hidden VCS directories (`/.git`, `/.svn`, `/.hg`)
  - `query -m sub -i` for query injection patterns
  - `req.hdr(...) -m sub -i` for header payloads
- Action: `http-request deny deny_status 403` (or `set-header X-WAF-Simulation` for simulate mode).

### 3. Caddy Server (`caddy`)
- **Native Caddyfile**: Idiomatic named matcher directives (`@waf_patch_<cat>_strict` / `@waf_patch_<cat>_heuristic`):
  - `path *.sql *.env *.bak *.key`
  - `path */.git/* */.svn/*`
  - `query *union*select*`
- Action: `respond @waf_patch_<cat> 403` (or `header ... X-WAF-Simulation "blocked"`).

### 4. Kubernetes Ingress (`k8s`)
- **YAML Manifest**: Production-ready Kubernetes Ingress manifest (`kind: Ingress`, `apiVersion: networking.k8s.io/v1`) using `nginx.ingress.kubernetes.io/server-snippet` with target host extraction. Multiple manifests in bundle separated by `---`.

### 5. Web UI & CLI Updates
- **Worker Web UI**:
  - Added tabs: `🔷 Azure WAF`, `🔶 HAProxy`, `🚀 Caddy`, `☸️ K8s Ingress` in `Virtual Patching Studio`.
  - Added dynamic format selector options: `Native Rules / Config`, `Terraform (HCL)`, `gcloud CLI Command`, `Azure CLI Command`.
  - Added automatic tab selection for Azure WAF and HAProxy upon fingerprinting.
  - Custom file extensions on download (`.cfg`, `.caddyfile`, `.yaml`, `.json`, `.tf`, `.sh`).
- **CLI**:
  - Added `--patch <vendor>` and `--waf <vendor>` support for `azure`, `haproxy`, `caddy`, `k8s`.
  - Added CLI preview for Azure CLI commands.
  - Multi-file output writing with dedicated extensions.

### 6. Tests
- Added unit test suites for Azure, HAProxy, Caddy, and Kubernetes Ingress in `packages/core/test/virtual-patch.spec.ts`.
- Added CLI unit tests for the new vendors in `packages/cli/test/cli.spec.ts`.
- All 362 monorepo unit and integration tests passing.