### PR TITLE
feat(cli): add --allow-local flag for local Docker and localhost WAF testing

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -189,11 +189,13 @@ checkCmd
 	.option('-q, --quiet', 'Suppress per-request logging, displaying only final results')
 	.option('--silent', 'Alias for --quiet')
 	.option('--fail-on-bypass', 'Exit with exit code 1 if any bypasses are detected', false)
+	.option('--allow-local', 'Allow testing localhost, 127.0.0.1, and private IP ranges (Docker/LAN)', false)
 	.addHelpText('after', detailedHelp)
 	.action(async (url: string, options: any) => {
 		const isQuiet = options.quiet || options.silent;
+		const allowLocal = Boolean(options.allowLocal);
 		try {
-			if (!isValidTargetUrl(url)) {
+			if (!isValidTargetUrl(url, { allowLocal })) {
 				console.error(colors.red(`Error: Invalid target URL "${url}" or restricted IP.`));
 				process.exit(1);
 			}
@@ -229,13 +231,13 @@ checkCmd
 				options.encodingVariations,
 				options.detectedWaf,
 				httpManipulationOpts,
-				{ fetch: customFetch, color: useColor, quiet: isQuiet }
+				{ fetch: customFetch, color: useColor, quiet: isQuiet, allowLocal }
 			);
 
 			let reverseReport: ReverseEngineeringReport | undefined = undefined;
 			if (options.reverse || options.reverseEngineer) {
 				if (!isQuiet) console.log(colors.cyan('\n[+] Executing deep WAF Reverse Engineering and OWASP CRS audit...'));
-				reverseReport = await runReverseEngineeringAudit(url, { fetch: customFetch, quiet: isQuiet, color: useColor });
+				reverseReport = await runReverseEngineeringAudit(url, { fetch: customFetch, quiet: isQuiet, color: useColor, allowLocal });
 			}
 
 			let patchReport: VirtualPatchReport | undefined = undefined;

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -22,7 +22,7 @@ export async function sendRequest(
 	useEnhancedPayloads: boolean = false,
 	detectedWAF?: string,
 	httpManipulation?: HTTPManipulationOptions,
-	options?: { fetch?: typeof fetch; color?: boolean; quiet?: boolean; rawPayload?: boolean },
+	options?: { fetch?: typeof fetch; color?: boolean; quiet?: boolean; rawPayload?: boolean; allowLocal?: boolean },
 ) {
 	const fetchFn = options?.fetch || globalThis.fetch;
 	try {
@@ -56,7 +56,7 @@ export async function sendRequest(
 		}
 
 		// Validate finalUrl after substitution to prevent SSRF
-		if (!isValidTargetUrl(finalUrl)) {
+		if (!isValidTargetUrl(finalUrl, { allowLocal: options?.allowLocal })) {
 			console.error(`Blocked SSRF attempt to: ${redactUrl(finalUrl)}`);
 			return { status: 'BLOCKED', is_redirect: false, responseTime: 0 };
 		}
@@ -115,7 +115,7 @@ export async function sendRequest(
 					if (!location) break;
 
 					const nextUrl = new URL(location, currentUrl).toString();
-					if (!isValidTargetUrl(nextUrl)) {
+					if (!isValidTargetUrl(nextUrl, { allowLocal: options?.allowLocal })) {
 						console.error(`Blocked SSRF redirect attempt to: ${redactUrl(nextUrl)}`);
 						return { status: 'BLOCKED', is_redirect: true, responseTime: Date.now() - startTime };
 					}
@@ -199,7 +199,7 @@ export async function handleApiCheckFiltered(
 	useEncodingVariations: boolean = false,
 	detectedWAF?: string,
 	httpManipulation?: HTTPManipulationOptions,
-	options?: { fetch?: typeof fetch; color?: boolean; quiet?: boolean; isWorker?: boolean },
+	options?: { fetch?: typeof fetch; color?: boolean; quiet?: boolean; isWorker?: boolean; allowLocal?: boolean },
 ): Promise<any[]> {
 	const METHODS = methods && methods.length ? methods : ['GET'];
 	const results: any[] = [];

--- a/packages/core/src/reverse-engineering/index.ts
+++ b/packages/core/src/reverse-engineering/index.ts
@@ -24,7 +24,7 @@ export async function runReverseEngineeringAudit(
 	url: string,
 	options?: ReverseEngineeringOptions,
 ): Promise<ReverseEngineeringReport> {
-	if (!isValidTargetUrl(url)) {
+	if (!isValidTargetUrl(url, { allowLocal: options?.allowLocal })) {
 		throw new Error('Invalid URL or restricted IP');
 	}
 

--- a/packages/core/src/reverse-engineering/types.ts
+++ b/packages/core/src/reverse-engineering/types.ts
@@ -75,4 +75,5 @@ export interface ReverseEngineeringOptions {
 	skipBodyLimit?: boolean;
 	skipAnomalyScore?: boolean;
 	maxRpsProbe?: number;
+	allowLocal?: boolean;
 }

--- a/packages/core/src/utils/security.ts
+++ b/packages/core/src/utils/security.ts
@@ -1,9 +1,13 @@
-export function isValidTargetUrl(urlString: string): boolean {
+export function isValidTargetUrl(urlString: string, options: { allowLocal?: boolean } = {}): boolean {
 	try {
 		const url = new URL(urlString);
 
 		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 			return false;
+		}
+
+		if (options.allowLocal) {
+			return true;
 		}
 
 		let hostname = url.hostname;

--- a/packages/core/src/waf-detection.ts
+++ b/packages/core/src/waf-detection.ts
@@ -137,8 +137,8 @@ export class WAFDetector {
 	/**
 	 * Perform active WAF detection by sending probe requests
 	 */
-	static async activeDetection(url: string, options?: { fetch?: typeof fetch; isWorker?: boolean }): Promise<WAFDetectionResult> {
-		if (!isValidTargetUrl(url)) {
+	static async activeDetection(url: string, options?: { fetch?: typeof fetch; isWorker?: boolean; allowLocal?: boolean }): Promise<WAFDetectionResult> {
+		if (!isValidTargetUrl(url, { allowLocal: options?.allowLocal })) {
 			throw new Error('Invalid URL or restricted IP');
 		}
 		const fetchFn = options?.fetch || globalThis.fetch;
@@ -320,13 +320,13 @@ export class WAFDetector {
 	/**
 	 * Detect WAF bypass opportunities
 	 */
-	static async detectBypassOpportunities(url: string, options?: { fetch?: typeof fetch }): Promise<{
+	static async detectBypassOpportunities(url: string, options?: { fetch?: typeof fetch; allowLocal?: boolean }): Promise<{
 		httpMethodsBypass: boolean;
 		headerBypass: boolean;
 		encodingBypass: boolean;
 		parameterPollution: boolean;
 	}> {
-		if (!isValidTargetUrl(url)) {
+		if (!isValidTargetUrl(url, { allowLocal: options?.allowLocal })) {
 			throw new Error('Invalid URL or restricted IP');
 		}
 		const fetchFn = options?.fetch || globalThis.fetch;


### PR DESCRIPTION
Adds `--allow-local` flag to CLI to enable testing local Docker containers, localhost, and LAN addresses while maintaining strict SSRF protection by default and permanently in the Cloudflare Worker API.