### PR TITLE
fix(reverse-engineering): pass allowLocal option down to all probe sendRequest calls

### DIFF
--- a/packages/core/src/reverse-engineering/anomaly-score-detector.ts
+++ b/packages/core/src/reverse-engineering/anomaly-score-detector.ts
@@ -24,11 +24,13 @@ export async function detectAnomalyScoringMode(
 			fetch: options?.fetch,
 			quiet: true,
 			rawPayload: true,
+			allowLocal: options?.allowLocal,
 		}),
 		sendRequest(url, 'GET', signal2Payload, undefined, undefined, false, false, undefined, undefined, {
 			fetch: options?.fetch,
 			quiet: true,
 			rawPayload: true,
+			allowLocal: options?.allowLocal,
 		}),
 	]);
 
@@ -58,7 +60,7 @@ export async function detectAnomalyScoringMode(
 		false,
 		undefined,
 		undefined,
-		{ fetch: options?.fetch, quiet: true, rawPayload: true },
+		{ fetch: options?.fetch, quiet: true, rawPayload: true, allowLocal: options?.allowLocal },
 	);
 
 	if (resScore5 && resScore5.status === 403) {
@@ -81,7 +83,7 @@ export async function detectAnomalyScoringMode(
 		false,
 		undefined,
 		undefined,
-		{ fetch: options?.fetch, quiet: true, rawPayload: true },
+		{ fetch: options?.fetch, quiet: true, rawPayload: true, allowLocal: options?.allowLocal },
 	);
 
 	if (resCritical && resCritical.status === 403) {
@@ -106,7 +108,7 @@ export async function detectAnomalyScoringMode(
 		false,
 		undefined,
 		undefined,
-		{ fetch: options?.fetch, quiet: true, rawPayload: true },
+		{ fetch: options?.fetch, quiet: true, rawPayload: true, allowLocal: options?.allowLocal },
 	);
 
 	if (resScore10 && resScore10.status === 403) {

--- a/packages/core/src/reverse-engineering/body-limit-detector.ts
+++ b/packages/core/src/reverse-engineering/body-limit-detector.ts
@@ -32,7 +32,7 @@ export async function detectBodyInspectionLimit(
 		false,
 		undefined,
 		undefined,
-		{ fetch: options?.fetch, quiet: true },
+		{ fetch: options?.fetch, quiet: true, allowLocal: options?.allowLocal },
 	);
 
 	if (!baselineRes || baselineRes.status !== 403) {
@@ -61,7 +61,7 @@ export async function detectBodyInspectionLimit(
 			false,
 			undefined,
 			undefined,
-			{ fetch: options?.fetch, quiet: true },
+			{ fetch: options?.fetch, quiet: true, allowLocal: options?.allowLocal },
 		);
 
 		if (res && res.status !== 403 && res.status !== 'ERR' && res.status !== 'BLOCKED') {
@@ -100,7 +100,7 @@ export async function detectBodyInspectionLimit(
 			false,
 			undefined,
 			undefined,
-			{ fetch: options?.fetch, quiet: true },
+			{ fetch: options?.fetch, quiet: true, allowLocal: options?.allowLocal },
 		);
 
 		if (res && res.status !== 403 && res.status !== 'ERR' && res.status !== 'BLOCKED') {

--- a/packages/core/src/reverse-engineering/index.ts
+++ b/packages/core/src/reverse-engineering/index.ts
@@ -64,7 +64,7 @@ export async function runReverseEngineeringAudit(
 				false,
 				undefined,
 				undefined,
-				{ fetch: options?.fetch, quiet: true, rawPayload: true },
+				{ fetch: options?.fetch, quiet: true, rawPayload: true, allowLocal: options?.allowLocal },
 			);
 
 			const responseTime = Date.now() - startTime;

--- a/packages/core/src/reverse-engineering/rate-limit-probe.ts
+++ b/packages/core/src/reverse-engineering/rate-limit-probe.ts
@@ -28,7 +28,7 @@ export async function probeRateLimit(
 				false,
 				undefined,
 				undefined,
-				{ fetch: options?.fetch, quiet: true },
+				{ fetch: options?.fetch, quiet: true, allowLocal: options?.allowLocal },
 			),
 		);
 


### PR DESCRIPTION
Propagates `options.allowLocal` to all sub-probes in `anomaly-score-detector.ts`, `body-limit-detector.ts`, `rate-limit-probe.ts`, and `reverse-engineering/index.ts` so reverse engineering audits on local Docker containers run cleanly without SSRF false alerts.