### PR TITLE
fix(virtual-patch): escape backslashes in NGINX regex for PCRE2 compatibility

### DIFF
--- a/packages/core/src/virtual-patch/generators/nginx.ts
+++ b/packages/core/src/virtual-patch/generators/nginx.ts
@@ -102,7 +102,7 @@ export function generateNginxPatches(
 					);
 				}
 				if (fileTokens.length > 0) {
-					const escapedFiles = fileTokens.map((f) => escapeNginxString(escapeRegex(f))).join('|');
+					const escapedFiles = fileTokens.map((f) => escapeRegex(f)).join('|');
 					locLines.push(
 						`# Block specific sensitive files`,
 						`location ~* /(${escapedFiles}) {`,

--- a/packages/core/src/virtual-patch/heuristics.ts
+++ b/packages/core/src/virtual-patch/heuristics.ts
@@ -158,7 +158,7 @@ export function escapeHclString(str: string): string {
  * Escapes strings for embedding inside NGINX configuration double-quoted regexes.
  */
 export function escapeNginxString(str: string): string {
-	return str.replace(/"/g, '\\"');
+	return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 /**


### PR DESCRIPTION
## Summary

- Escapes backslashes in double-quoted NGINX configuration strings so that PCRE2 compiler receives valid escape sequences (preventing `PCRE2 does not support \\F, \\L, \\l, \\N{name}, \\U, or \\u` errors on Unicode bypass payloads).
- Keeps unquoted `location ~* /(...)` directives cleanly escaped without superfluous string-escaping slashes.
- Tested and verified against real Docker NGINX reverse-proxy container.